### PR TITLE
Add security deposit information for BTC, LTC and DASH

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -282,6 +282,20 @@ banner: /images/faq.png
 <p><a name="14"></a><strong> If I don’t have any bitcoins, how can I obtain enough to pay the security deposit and mining fee on my first trade?</strong></p>
 <p>We recognize that this could be a barrier to entry to bitcoin beginners.</p>
 <p>The security deposit is needed to protect Bisq from fraud and abuse. That said, we will always investigate possible solutions which would allow new users to trade without needing bitcoin first.</p>
+<p>Following security deposit values are set by default for</p>
+<strong>buyer</strong>:
+<ul>
+  <li>0.01 BTC (minimum 0.0005 BTC, maximum 0.05 BTC)</li>
+  <li>2.00 LTC (minimum 0.0600 LTC, maximum 12.00 LTC)</li>
+  <li>0.50 DASH (minimum 0.0150 DASH, maximum 3.00 DASH)</li>
+</ul>
+<strong>seller</strong>:
+<ul>
+  <li>0.003 BTC</li>
+  <li>0.600 LTC</li>
+  <li>0.150 DASH</li>
+</ul>
+
 <p>Bitcoin can be purchased via many channels: friends or family, Bitcoin meetups, Bitcoin ATMs, Vouchers, Localbitcoins or from any of the centralized exchanges.</p>
 
 <p><a name="15"></a><strong>Does Bisq support ‘XYZ’ payments?</strong></p>


### PR DESCRIPTION
I've added default, max & min values for security deposits (buyer, seller) for BTC, LTC and DASH. I left out DODGE as it is not selectable atm within the client.