### PR TITLE
Add links to new https://docs.bisq.network site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
         <nav>
           <ul id="menuUl" class="menu">
             <li class="tnskip">&nbsp;</li><li id="menu-item-40" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home current-menu-item page_item page-item-6 current_page_item menu-item-40"><a href="/">Home</a></li>
-            <li id="menu-item-1427" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1427"><a href="https://markets.bisq.network/">Markets</a></li>
+            <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="https://docs.bisq.network">Docs <sup>(NEW)</sup></a></li>
             <li id="menu-item-38" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-38"><a href="/philosophy/">Philosophy</a></li>
             <li id="menu-item-36" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-36"><a href="/community/">Community</a></li>
             <li id="menu-item-468" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-468"><a href="/faq/">FAQ</a></li>
@@ -77,6 +77,7 @@
       <nav class="nav-footer">
         <ul id="menuUIfooter" class="menu">
           <li class="tnskip" >&nbsp;</li><li id="menu-item-42" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-42"><a href="/press/">Press</a></li>
+          <li id="menu-item-453" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-453"><a href="https://markets.bisq.network">Markets</a></li>
           <li id="menu-item-453" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-453"><a href="/roadmap/">Roadmap</a></li>
           <li id="menu-item-1601" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1601"><a href="/contribute/">Contribute</a></li>
           <li id="menu-item-451" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-451"><a href="/dao/">DAO</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,8 +62,8 @@
       <div class="homebox"><a href="https://github.com/bisq-network/exchange">
         <img src="/images/source_button.png" alt="Source"/></a>
       </div>
-      <div class="homebox"><a href="/docs/exchange/whitepaper">
-        <img src="/images/whitepaper_button.png" alt="Whitepaper"/></a>
+      <div class="homebox"><a href="https://docs.bisq.network">
+        <img src="/images/whitepaper_button.png" alt="Docs"/></a>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
The new docs site is getting substantial now, especially with the completion of the getting started guide in bisq-network/bisq-docs#45, and it's probably overdue in any case that we add links to the site from the main navigation of the website.

@bisq-network/design-contributors, you'll notice in 93e4156 that I just changed the target of the 'whitepaper' button without actually changing the text of the button from 'Whitepaper' to 'Docs'. This is because the button and its text are an image. I do not know whether we have the original materials for these buttons somewhere (@manfredkarrer, do you know?), but in any case, it would be good to change the text on that button if somebody wants to knock it out.