### PR TITLE
Add convenience redirects for getting started guide

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -26,6 +26,8 @@ https://bisq.io https://bisq.network 301
 /intro https://docs.bisq.network/intro.html 302
 /contrib-checklist /contributor-checklist 302
 /contributor-checklist https://docs.bisq.network/contributor-checklist.html 302
+/get-started https://docs.bisq.network/getting-started.html 302
+/getting-started https://docs.bisq.network/getting-started.html 302
 
 /arbitration_system.pdf /docs/exchange/arbitration-system 301
 /docs/arbitration-system.pdf /docs/exchange/arbitration-system 301


### PR DESCRIPTION
When merged, this will enable the following shortcuts:

 - https://bisq.network/get-started
 - https://bisq.network/getting-started

/cc @bisq-network/docs-contributors