### PR TITLE
Add missing <head> tag to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
 


### PR DESCRIPTION
Previously, this tag was missing entirely. Doesn't seem to have caused
any problems, but noticed it was missing when looking over our analytics
configuration.

/cc @ripcurlx