### PR TITLE
Extract 'version' variable on /downloads page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -2,6 +2,7 @@
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
 banner: /images/roadmap1.png
+version: 0.7.1
 ---
 <h1>Bisq Downloads</h1>
 
@@ -41,20 +42,20 @@ a.selected::after {
     <tr>
       <td>Windows</td>
       <td>
-        <a id="dl-win32" href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/Bisq-32bit-0.7.1.exe">32 Bit</a> |
-        <a id="dl-win64" href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/Bisq-64bit-0.7.1.exe">64 Bit</a>
+        <a id="dl-win32" href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/Bisq-32bit-{{ page.version }}.exe">32 Bit</a> |
+        <a id="dl-win64" href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/Bisq-64bit-{{ page.version }}.exe">64 Bit</a>
       </td>
     </tr>
     <tr>
       <td>Mac</td>
-      <td><a id="dl-mac" href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/Bisq-0.7.1.dmg">.dmg</a>
+      <td><a id="dl-mac" href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/Bisq-{{ page.version }}.dmg">.dmg</a>
       </td>
     </tr>
     <tr>
       <td>Debian/Ubuntu</td>
       <td>
-        <a id="dl-deb32" href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/Bisq-32bit-0.7.1.deb">32 Bit</a> |
-        <a id="dl-deb64" href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/Bisq-64bit-0.7.1.deb">64 Bit</a>
+        <a id="dl-deb32" href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/Bisq-32bit-{{ page.version }}.deb">32 Bit</a> |
+        <a id="dl-deb64" href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/Bisq-64bit-{{ page.version }}.deb">64 Bit</a>
       </td>
     </tr>
     <p>
@@ -65,17 +66,17 @@ a.selected::after {
     </tr>
     <tr>
       <td>Source Code</td>
-      <td><a href="https://github.com/bisq-network/exchange/archive/v0.7.1.zip">zip</a> |
-        <a href="https://github.com/bisq-network/exchange/archive/v0.7.1.tar.gz">tar.gz</a></td>
+      <td><a href="https://github.com/bisq-network/exchange/archive/v{{ page.version }}.zip">zip</a> |
+        <a href="https://github.com/bisq-network/exchange/archive/v{{ page.version }}.tar.gz">tar.gz</a></td>
     </tr>
     <tr>
       <td>Release Notes</td>
-      <td><a href="https://github.com/bisq-network/exchange/releases/tag/v0.7.1">Release Notes for v0.7.1</a></td>
+      <td><a href="https://github.com/bisq-network/exchange/releases/tag/v{{ page.version }}">Release Notes for v{{ page.version }}</a></td>
     </tr>
     <tr>
       <td>Verification</td>
-      <td><a href="https://github.com/bisq-network/exchange/releases/tag/v0.7.1">PGP signatures</a> |
-        <a href="https://github.com/bisq-network/exchange/releases/download/v0.7.1/F379A1C6.asc">PGP Public Key</a></td>
+      <td><a href="https://github.com/bisq-network/exchange/releases/tag/v{{ page.version }}">PGP signatures</a> |
+        <a href="https://github.com/bisq-network/exchange/releases/download/v{{ page.version }}/F379A1C6.asc">PGP Public Key</a></td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
Previously, when releasing a new version, multiple error-prone changes
to the downloads page were required. Now, the `version` variable has
been extracted, meaning that it is necessary to update just one line in
the front matter of the page. See https://jekyllrb.com/docs/variables/
for details.

/cc @ripcurlx; see #66 to see what was required prior to this change.