### PR TITLE
Add link from /downloads to Getting Started guide

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -80,3 +80,7 @@ a.selected::after {
     </tr>
   </table>
 </div>
+
+<br>
+
+<p>See <a href="https://docs.bisq.network/getting-started">Getting Started with Bisq</a> for instructions how to complete your first trade.</p>


### PR DESCRIPTION
The Getting Started guide is designed to help new users. Most traffic on the
site routes to the /downloads page today (it is 22% of overall pageviews).
Adding a prominent link from this page to the Getting Started guide increases
the visibility / discoverability of this resource in a natural and intuitive
way, and should thus drive more traffic to it, such that we get more informed
and capable new users right from their very first interactions with Bisq.

/cc @m52go