### PR TITLE
Add download links to os text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Bisq
-url: "https://bisq.network/"
+url: "https://bisq.network"
 markdown: kramdown
 permalink: /blog/:title/
 livereload: true

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -19,17 +19,6 @@
 
                         <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
 
-                          <div class="id-win32 hidden">
-                            <div class="float-left">
-                                    <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
-                                    Download for Windows
-                            </div>
-                            <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe">32bits</a>
-                            </div>
-                          </div>
-
                           <div class="id-win64 hidden">
                             <div class="float-left">
                                     <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
@@ -178,8 +167,7 @@
 
 
                     <p class="text-muted mb-0 mt-1 small" style="opacity: 0.5">
-                      v{{ site.client_version }} — <span class="id-win32 hidden">You appear to be running Windows 32 bit.</span>
-                                                   <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
+                      v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
                                                    <span class="id-mac hidden">You appear to be using a Mac.</span>
                                                    <span class="id-deb32 hidden">You appear to be using Debian/Ubuntu 32 bit.</span>
                                                    <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</span>

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -8,9 +8,8 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
+  <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Windows</a>
   <div class="float-right">
-    <a class="dl-win32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">32 Bit</a> |
     <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
   </div>
 </div>
@@ -18,7 +17,7 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> Download for Mac
+  <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Mac</a>
   <div class="float-right">
     <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.dmg</a>
   </div>
@@ -37,7 +36,7 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-linux-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-linux-w.svg" class="os-icon os-icon-w" /> Download for Arch Linux
+  <img src="{{ site.url }}/images/icon-linux-w.svg" class="os-icon os-icon-w" /> <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Arch Linux</a>
   <div class="float-right">
     <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Arch User Repo</a></div>
 </div>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -17,13 +17,9 @@ $(document).ready(function() {
       $('.id-all').removeClass('shown').addClass('hidden');
       break;
     case "Windows":
-      // if 64-bit
       if (navigator.userAgent.indexOf("WOW64") != -1 || navigator.userAgent.indexOf("Win64") != -1) {
         $('.dl-win64').addClass('selected');
         $('.id-win64').removeClass('hidden').addClass('shown');
-      } else {
-        $('.dl-win32').addClass('selected');
-        $('.id-win32').removeClass('hidden').addClass('shown');
       }
       $('.id-all').removeClass('shown').addClass('hidden');
       break;
@@ -59,7 +55,7 @@ $(document).ready(function() {
   //console.log(OSName);
 
   // add virtual pageview and event tracking for download attempts
-  $('.dl-win32, .dl-win64, .dl-mac, .dl-deb32, .dl-deb64').click(function() {
+  $('.dl-win64, .dl-mac, .dl-deb32, .dl-deb64').click(function() {
     ga('send', 'pageview', location.pathname + 'release');
     ga('send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop());
   });


### PR DESCRIPTION
1. Text such as "Download for Mac" and "Download for Windows" in download menus are now linked to downloads (per discussion with @ripcurlx).
2. Download links for 32-bit Windows are removed.
3. Removed trailing slash for root URL. It was causing double slashes in site links (e.g., bisq.network//roadmap).

