### PR TITLE
Fix blank under 'get started' button on mobile

### DIFF
--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -173,7 +173,7 @@
                                                    <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</span>
                                                    <span class="id-rpm32 hidden">You appear to be using Redhat/Fedora/CentOS 32 bit.</span>
                                                    <span class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS 64 bit.</span>
-                                                   <span class="id-all">Current Version</span> <!-- fallback text if no desktop os recognized -->
+                                                   <span class="id-all hidden">Current Version</span> <!-- fallback text if no desktop os recognized -->
                     </p>
 
 

--- a/downloads.html
+++ b/downloads.html
@@ -20,7 +20,6 @@ version: 0.9.0
     <tr class="border-bottom">
       <td>Windows</td>
       <td>
-        <a class="dl-win32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe">32 Bit</a> |
         <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">64 Bit</a>
       </td>
     </tr>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -14,14 +14,12 @@ $(document).ready(function() {
     case "MacOS":
       $('.dl-mac').addClass('selected');
       $('.id-mac').removeClass('hidden').addClass('shown');
-      $('.id-all').removeClass('shown').addClass('hidden');
       break;
     case "Windows":
       if (navigator.userAgent.indexOf("WOW64") != -1 || navigator.userAgent.indexOf("Win64") != -1) {
         $('.dl-win64').addClass('selected');
         $('.id-win64').removeClass('hidden').addClass('shown');
       }
-      $('.id-all').removeClass('shown').addClass('hidden');
       break;
     case "Linux":
       var is64 = navigator.userAgent.indexOf("x86_64") != -1;
@@ -34,7 +32,6 @@ $(document).ready(function() {
         $(is64 ? '.dl-rpm64' : '.dl-rpm32').addClass('selected');
         $(is64 ? '.id-rpm64' : '.id-rpm32').removeClass('hidden').addClass('shown');
       }
-      $('.id-all').removeClass('shown').addClass('hidden');
       break;
   }
 
@@ -45,9 +42,11 @@ $(document).ready(function() {
   }
   if (/android/i.test(userAgent)) {
     $('.downloads-android').removeClass('hidden').addClass('shown');
+    $('.id-all').removeClass('hidden').addClass('shown');
   }
   if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
     $('.downloads-ios').removeClass('hidden').addClass('shown');
+    $('.id-all').removeClass('hidden').addClass('shown');
   }
 
 


### PR DESCRIPTION
Another small PR to fix 2 small issues:
1. On mobile, there's currently a blank under the Get Started button. This PR adds fallback text.
2. It removes the 32-bit Windows download link from the actual /downloads page (forgot this in my last PR).