### PR TITLE
Fix typo in Windows 64 bit download link text

### DIFF
--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -26,7 +26,7 @@
                                     Download for Windows
                             </div>
                             <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">64bits</a>
+                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">64 Bit</a>
                             </div>
                           </div>
 


### PR DESCRIPTION
Changed "64bits" to "64 Bit":
![image](https://user-images.githubusercontent.com/603793/49495465-e5509580-f817-11e8-8eca-154705e1f5c8.png)