### PR TITLE
Rework download links

### DIFF
--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -26,7 +26,7 @@
                                     Download for Windows
                             </div>
                             <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">64bits</a>
+                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
                             </div>
                           </div>
 
@@ -48,7 +48,7 @@
                                     Download for Debian/Ubuntu
                             </div>
                             <div class="float-right">
-                              <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
+                              <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
                             </div>
                           </div>
 
@@ -149,10 +149,10 @@
 
 
                     <p class="text-muted mb-0 mt-1 small" style="opacity: 0.5">
-                      v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
+                      v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows.</span>
                                                    <span class="id-mac hidden">You appear to be using a Mac.</span>
-                                                   <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</span>
-                                                   <span class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS 64 bit.</span>
+                                                   <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu.</span>
+                                                   <span class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS.</span>
                                                    <span class="id-all hidden">Current Version</span> <!-- fallback text if no desktop os recognized -->
                     </p>
 

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -20,7 +20,7 @@
                         <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
 
                           <div class="id-win64 hidden">
-                            <div class="float-left">
+                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe';">
                                     <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
                                     <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
                                     Download for Windows
@@ -31,7 +31,7 @@
                           </div>
 
                           <div class="id-mac hidden">
-                            <div class="float-left">
+                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg';">
                                     <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
                                     <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
                                     Download for Mac
@@ -42,7 +42,7 @@
                           </div>
 
                           <div class="id-deb64 hidden">
-                            <div class="float-left">
+                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb';">
                                     <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
                                     <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
                                     Download for Debian/Ubuntu
@@ -53,7 +53,7 @@
                           </div>
 
                           <div class="id-all hidden">
-                            <div class="float-left">
+                            <div class="float-left" onclick="location.href='{{ site.url }}/downloads';">
                                     <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g">
                                     <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w">
                                     Downloads

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -19,6 +19,17 @@
 
                         <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
 
+                          <div class="id-win32 hidden">
+                            <div class="float-left">
+                                    <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
+                                    <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
+                                    Download for Windows
+                            </div>
+                            <div class="float-right">
+                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe">32bits</a>
+                            </div>
+                          </div>
+
                           <div class="id-win64 hidden">
                             <div class="float-left">
                                     <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
@@ -167,7 +178,8 @@
 
 
                     <p class="text-muted mb-0 mt-1 small" style="opacity: 0.5">
-                      v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
+                      v{{ site.client_version }} — <span class="id-win32 hidden">You appear to be running Windows 32 bit.</span>
+                                                   <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
                                                    <span class="id-mac hidden">You appear to be using a Mac.</span>
                                                    <span class="id-deb32 hidden">You appear to be using Debian/Ubuntu 32 bit.</span>
                                                    <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</span>

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -19,17 +19,6 @@
 
                         <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
 
-                          <div class="id-win32 hidden">
-                            <div class="float-left">
-                                    <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
-                                    Download for Windows
-                            </div>
-                            <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe">32bits</a>
-                            </div>
-                          </div>
-
                           <div class="id-win64 hidden">
                             <div class="float-left">
                                     <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
@@ -52,20 +41,6 @@
                             </div>
                           </div>
 
-
-
-                          <div class="id-deb32 hidden">
-                            <div class="float-left">
-                                    <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
-                                    Download for Debian/Ubuntu
-                            </div>
-                            <div class="float-right">
-                              <a class="dl-deb32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">32 Bit</a>
-                            </div>
-                          </div>
-
-
                           <div class="id-deb64 hidden">
                             <div class="float-left">
                                     <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
@@ -76,10 +51,6 @@
                               <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
                             </div>
                           </div>
-
-
-
-
 
                           <div class="id-all hidden">
                             <div class="float-left">
@@ -178,12 +149,9 @@
 
 
                     <p class="text-muted mb-0 mt-1 small" style="opacity: 0.5">
-                      v{{ site.client_version }} — <span class="id-win32 hidden">You appear to be running Windows 32 bit.</span>
-                                                   <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
+                      v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows 64 bit.</span>
                                                    <span class="id-mac hidden">You appear to be using a Mac.</span>
-                                                   <span class="id-deb32 hidden">You appear to be using Debian/Ubuntu 32 bit.</span>
                                                    <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</span>
-                                                   <span class="id-rpm32 hidden">You appear to be using Redhat/Fedora/CentOS 32 bit.</span>
                                                    <span class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS 64 bit.</span>
                                                    <span class="id-all hidden">Current Version</span> <!-- fallback text if no desktop os recognized -->
                     </p>

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -153,7 +153,6 @@
                       v{{ site.client_version }} — <span class="id-win64 hidden">You appear to be running Windows.</span>
                                                    <span class="id-mac hidden">You appear to be using a Mac.</span>
                                                    <span class="id-deb64 hidden">You appear to be using Debian/Ubuntu.</span>
-                                                   <span class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS.</span>
                                                    <span class="id-all hidden">Current Version</span> <!-- fallback text if no desktop os recognized -->
                     </p>
 

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -24,7 +24,7 @@
                                       Download for Windows
                                   </div>
                                   <div class="float-right">
-                                      <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+                                      <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
                                   </div>
                               </div>
 
@@ -35,7 +35,7 @@
                                       Download for Mac
                                   </div>
                                   <div class="float-right">
-                                      <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+                                      <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
                                   </div>
                               </div>
 
@@ -46,7 +46,7 @@
                                       Download for Debian/Ubuntu
                                   </div>
                                   <div class="float-right">
-                                      <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
+                                      <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
                                   </div>
                               </div>
 
@@ -73,39 +73,29 @@
                       </div>
 
 
-
-
-
-
-
-
                       <a href="{{ site.url }}/downloads" class="downloads-mobile btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn ">
-                                <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g">
-                                <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w">
-                                Downloads
+                          <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g">
+                          <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w">
+                          Downloads
                       </a>
 
 
-                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" class="downloads-android hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn " onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download Android App');">
-                                <img src="{{ site.url }}/images/icon-android-g.svg" class="os-icon os-icon-g">
-                                <img src="{{ site.url }}/images/icon-android-w.svg" class="os-icon os-icon-w">
-                                Get Android Notifications App
+                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" class="downloads-android hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'android-notifications');">
+                          <img src="{{ site.url }}/images/icon-android-g.svg" class="os-icon os-icon-g">
+                          <img src="{{ site.url }}/images/icon-android-w.svg" class="os-icon os-icon-w">
+                          Get Android Notifications App
                       </a>
 
 
-                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn " onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download iOS App');">
-                                <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
-                                <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
-                                Get iOS Notifications App
+                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'ios-notifications');">
+                          <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
+                          <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
+                          Get iOS Notifications App
                       </a>
 
 
-
-
-
-                      <a href="https://docs.bisq.network/getting-started.html" target="_blank" class="btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn " onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download Whitepaper');">
-
-                                Get Started »
+                      <a href="https://docs.bisq.network/getting-started.html" target="_blank" class="btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn">
+                          Get Started »
                       </a>
 
                       {% comment %}

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -1,5 +1,3 @@
-
-
 <div class="container fadeIn">
 
         <main class="bd-masthead" id="content" role="main">
@@ -17,80 +15,60 @@
 
                       <div class="downloads-desktop btn-group os-selector-home col-sm-12 col-md-12 col-lg-5 px-0">
 
-                        <!-- This what displays on the dropdown in collapsed state -->
-                        <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
+                          <!-- This what displays on the dropdown in collapsed state -->
+                          <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button" data-bisq-version="{{ site.client_version }}" data-site-url="{{ site.url }}">
+                              <div class="id-win64 hidden">
+                                  <div class="float-left">
+                                      <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
+                                      <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
+                                      Download for Windows
+                                  </div>
+                                  <div class="float-right">
+                                      <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+                                  </div>
+                              </div>
 
-                          <div class="id-win64 hidden">
-                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe';">
-                                    <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
-                                    Download for Windows
-                            </div>
-                            <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
-                            </div>
+                              <div class="id-mac hidden">
+                                  <div class="float-left">
+                                      <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
+                                      <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
+                                      Download for Mac
+                                  </div>
+                                  <div class="float-right">
+                                      <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+                                  </div>
+                              </div>
+
+                              <div class="id-deb64 hidden">
+                                  <div class="float-left">
+                                      <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
+                                      <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
+                                      Download for Debian/Ubuntu
+                                  </div>
+                                  <div class="float-right">
+                                      <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
+                                  </div>
+                              </div>
+
+                              <div class="id-all hidden">
+                                  <div class="float-left">
+                                      <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g">
+                                      <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w">
+                                      Downloads
+                                  </div>
+                                  <div class="float-right">
+                                      <a href="{{ site.url }}/downloads">Get Bisq</a>
+                                  </div>
+                              </div>
+                          </button>
+
+                          <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split hero-btn shadow-btn " data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                              <span class="sr-only">Toggle Dropdown</span>
+                          </button>
+
+                          <div class="dropdown-menu dropdown-menu-right shadow-lg">
+                              {% include os_selector_options.html %}
                           </div>
-
-                          <div class="id-mac hidden">
-                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg';">
-                                    <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
-                                    Download for Mac
-                            </div>
-                            <div class="float-right">
-                              <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
-                            </div>
-                          </div>
-
-                          <div class="id-deb64 hidden">
-                            <div class="float-left" onclick="location.href='https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb';">
-                                    <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
-                                    Download for Debian/Ubuntu
-                            </div>
-                            <div class="float-right">
-                              <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
-                            </div>
-                          </div>
-
-                          <div class="id-all hidden">
-                            <div class="float-left" onclick="location.href='{{ site.url }}/downloads';">
-                                    <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g">
-                                    <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w">
-                                    Downloads
-                            </div>
-                            <div class="float-right">
-                              <a href="{{ site.url }}/downloads" target="_blank">Get Bisq</a>
-                            </div>
-                          </div>
-
-
-
-
-
-
-
-
-
-
-                        </button>
-
-
-
-
-
-
-
-
-                        <button type="button" class="btn btn-lg btn-secondary dropdown-toggle dropdown-toggle-split hero-btn shadow-btn " data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="sr-only">Toggle Dropdown</span>
-                            </button>
-
-                        <div class="dropdown-menu dropdown-menu-right shadow-lg">
-                            {% include os_selector_options.html %}
-                        </div>
-
-
 
                       </div>
 

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -17,6 +17,7 @@
 
                       <div class="downloads-desktop btn-group os-selector-home col-sm-12 col-md-12 col-lg-5 px-0">
 
+                        <!-- This what displays on the dropdown in collapsed state -->
                         <button class="btn btn-outline-secondary btn-lg selected-os-download btn-icon shadow-btn" type="button">
 
                           <div class="id-win64 hidden">

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -8,8 +8,9 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Windows</a>
+  <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
   <div class="float-right">
+    <a class="dl-win32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">32 Bit</a> |
     <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
   </div>
 </div>
@@ -17,7 +18,7 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Mac</a>
+  <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> Download for Mac
   <div class="float-right">
     <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.dmg</a>
   </div>
@@ -36,7 +37,7 @@
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-linux-g.svg" class="os-icon os-icon-g" />
-  <img src="{{ site.url }}/images/icon-linux-w.svg" class="os-icon os-icon-w" /> <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Download for Arch Linux</a>
+  <img src="{{ site.url }}/images/icon-linux-w.svg" class="os-icon os-icon-w" /> Download for Arch Linux
   <div class="float-right">
     <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Arch User Repo</a></div>
 </div>

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -2,7 +2,7 @@
   <img src="{{ site.url }}/images/icon-download-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-download-w.svg" class="os-icon os-icon-w" />All Downloads
   <div class="float-right">
-    <a href="{{ site.url }}/downloads/" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Go to Downloads Page</a>
+    <a href="{{ site.url }}/downloads/">Go to Downloads Page</a>
   </div>
 </div>
 
@@ -10,7 +10,7 @@
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
   <div class="float-right">
-    <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.exe</a>
+    <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
   </div>
 </div>
 
@@ -19,7 +19,7 @@
   <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> Download for Mac
   <div class="float-right">
-    <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.dmg</a>
+    <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
   </div>
 </div>
 
@@ -28,7 +28,7 @@
   <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" /> Download for Debian/Ubuntu
   <div class="float-right">
-    <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
+    <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
   </div>
 </div>
 
@@ -37,22 +37,22 @@
   <img src="{{ site.url }}/images/icon-linux-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-linux-w.svg" class="os-icon os-icon-w" /> Download for Arch Linux
   <div class="float-right">
-    <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">Arch User Repo</a></div>
+    <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">Arch User Repo</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-opensource-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-opensource-w.svg" class="os-icon os-icon-w" /> Source Code
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.zip" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">zip</a> |
-    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.tar.gz" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">tar.gz</a></div>
+    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.zip">zip</a> |
+    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-notes-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-notes-w.svg" class="os-icon os-icon-w" /> Release Notes
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">v0.9.0</a>
+    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">v0.9.0</a>
   </div>
 </div>
 
@@ -60,6 +60,6 @@
   <img src="{{ site.url }}/images/icon-verification-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-verification-w.svg" class="os-icon os-icon-w" /> Verification
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">PGP signatures</a> |
-    <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/29CDFD3B.asc" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">PGP Public Key</a></div>
+    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">PGP signatures</a> |
+    <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></div>
 </div>

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -10,7 +10,7 @@
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
   <div class="float-right">
-    <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
+    <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.exe</a>
   </div>
 </div>
 
@@ -28,7 +28,7 @@
   <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" /> Download for Debian/Ubuntu
   <div class="float-right">
-    <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
+    <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">.deb</a>
   </div>
 </div>
 

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -10,7 +10,6 @@
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
   <div class="float-right">
-    <a class="dl-win32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">32 Bit</a> |
     <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
   </div>
 </div>
@@ -29,7 +28,6 @@
   <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" /> Download for Debian/Ubuntu
   <div class="float-right">
-    <a class="dl-deb32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">32 Bit</a> |
     <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download v0.9.0');">64 Bit</a>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,85 +1,87 @@
 <!doctype html>
 <html lang="en">
 
-<head>
-  <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <head>
 
-  <meta name="author" content="Bisq">
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
 
-  <meta name="description" content="{{ site.description }}">
-  <meta name="image" content="{{ site.url }}/images/bisq-og.jpg">
-  <meta itemprop="name" content="Bisq">
-  <meta itemprop="description" content="{{ site.description }}">
-  <meta itemprop="image" content="{{ site.url }}/images/bisq-og.jpg">
-  <meta name="og:title" content="{{ page.title }}">
-  <meta name="og:description" content="{{ site.description }}">
-  <meta name="og:image" content="{{ site.url }}/images/bisq-og.jpg">
-  <meta name="og:site_name" content="Bisq - The decentralized Bitcoin exchange">
-  <meta name="og:type" content="website">
-  <meta property="twitter:title" content="{{ page.title }}">
-  <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:site" content="Bisq - The decentralized Bitcoin exchange">
-  <meta name="twitter:creator" content="@bisq_network">
-  <link rel="canonical" href="{{ site.url }}">
+        <meta name="author" content="Bisq">
 
+        <meta name="description" content="{{ site.description }}">
+        <meta name="image" content="{{ site.url }}/images/bisq-og.jpg">
+        <meta itemprop="name" content="Bisq">
+        <meta itemprop="description" content="{{ site.description }}">
+        <meta itemprop="image" content="{{ site.url }}/images/bisq-og.jpg">
+        <meta name="og:title" content="{{ page.title }}">
+        <meta name="og:description" content="{{ site.description }}">
+        <meta name="og:image" content="{{ site.url }}/images/bisq-og.jpg">
+        <meta name="og:site_name" content="Bisq - The decentralized Bitcoin exchange">
+        <meta name="og:type" content="website">
+        <meta property="twitter:title" content="{{ page.title }}">
+        <meta property="twitter:card" content="summary_large_image">
+        <meta property="twitter:site" content="Bisq - The decentralized Bitcoin exchange">
+        <meta name="twitter:creator" content="@bisq_network">
+        <link rel="canonical" href="{{ site.url }}">
 
+        <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+        <link href="{{ site.url }}/css/bootstrap.css" rel="stylesheet">
+        <link href="{{ site.url }}/css/styles.css" rel="stylesheet">
 
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}/images/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}/images/bisq-fav.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}/images/bisq-fav.png">
+        <link rel="icon" type="image/x-icon" href="{{ site.url }}/favicon.ico" />
+        <link rel="manifest" href="/site.webmanifest">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#404040">
+        <meta name="msapplication-TileColor" content="#ffffff">
+        <meta name="theme-color" content="#ffffff">
 
+        <title>{{ page.title }}</title>
 
+        <script src="{{ site.url }}/js/jquery-3.3.1.min.js"></script>
+        <script src="{{ site.url }}/js/popper.min.js"></script>
+        <script src="{{ site.url }}/js/bootstrap.min.js"></script>
+        <script src="{{ site.url }}/js/scripts.js"></script>
 
-  <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
-  <link href="{{ site.url }}/css/bootstrap.css" rel="stylesheet">
-  <link href="{{ site.url }}/css/styles.css" rel="stylesheet">
+    </head>
 
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ site.url }}/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ site.url }}/images/bisq-fav.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ site.url }}/images/bisq-fav.png">
-  <link rel="icon" type="image/x-icon" href="{{ site.url }}/favicon.ico" />
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#404040">
-  <meta name="msapplication-TileColor" content="#ffffff">
-  <meta name="theme-color" content="#ffffff">
-
-  <title>{{ page.title }}</title>
-
-
-  <script src="{{ site.url }}/js/jquery-3.3.1.min.js"></script>
-  <script src="{{ site.url }}/js/popper.min.js"></script>
-  <script src="{{ site.url }}/js/bootstrap.min.js"></script>
-  <script src="{{ site.url }}/js/scripts.js"></script>
-
+    <body class="home page-template-default page page-id-6 custom-background">
 
 
+        {% include main_nav.html %}
 
-</head>
+            {% if page.url == '/' %}
 
+                <div class="outter">
+                    {% include homepage_content.html %}
+                </div>
 
-<body class="home page-template-default page page-id-6 custom-background">
+            {% else %}
 
+                <div class="outter">
+                    {{ content }}
+                </div>
 
-  {% include main_nav.html %}
-
-    {% if page.url == '/' %}
-
-      <div class="outter">
-        {% include homepage_content.html %}
-      </div>
-
-    {% else %}
-
-      <div class="outter">
-        {{ content }}
-      </div>
-
-    {% endif %}
+            {% endif %}
 
 
-  {% include footer.html %}
+        {% include footer.html %}
 
 
-</body>
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+            ga('create', 'UA-104074395-1', 'auto');
+            {% if page.url == '/404.html' %}
+            ga('send', 'pageview', '/404error/?url=' + document.location.pathname + document.location.search + '&ref=' + document.referrer );
+            {% else %}
+            ga('send', 'pageview');
+            {% endif %}
+        </script>
 
-
+    </body>
 </html>

--- a/downloads.html
+++ b/downloads.html
@@ -17,7 +17,7 @@ version: 0.9.0
     <tr class="border-bottom">
       <td>Windows</td>
       <td>
-        <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">64 Bit</a>
+        <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
       </td>
     </tr>
     <tr class="border-bottom">
@@ -28,7 +28,7 @@ version: 0.9.0
     <tr class="border-bottom">
       <td>Debian/Ubuntu</td>
       <td>
-        <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">64 Bit</a>
+        <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
       </td>
     </tr>
     <tr class="border-bottom">

--- a/downloads.html
+++ b/downloads.html
@@ -11,7 +11,6 @@ version: 0.9.0
   <div class="id-win64 hidden">You appear to be running Windows.</div>
   <div class="id-mac hidden">You appear to be using a Mac.</div>
   <div class="id-deb64 hidden">You appear to be using Debian/Ubuntu.</div>
-  <div class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS.</div>
 
   <table class="all-downloads mt-5">
     <tr class="border-bottom">

--- a/downloads.html
+++ b/downloads.html
@@ -8,13 +8,10 @@ version: 0.9.0
 
 
 <div class="mt-5 mb-2">
-  <div class="id-win32 hidden">You appear to be running Windows 32 bit.</div>
-  <div class="id-win64 hidden">You appear to be running Windows 64 bit.</div>
+  <div class="id-win64 hidden">You appear to be running Windows.</div>
   <div class="id-mac hidden">You appear to be using a Mac.</div>
-  <div class="id-deb32 hidden">You appear to be using Debian/Ubuntu 32 bit.</div>
-  <div class="id-deb64 hidden">You appear to be using Debian/Ubuntu 64 bit.</div>
-  <div class="id-rpm32 hidden">You appear to be using Redhat/Fedora/CentOS 32 bit.</div>
-  <div class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS 64 bit.</div>
+  <div class="id-deb64 hidden">You appear to be using Debian/Ubuntu.</div>
+  <div class="id-rpm64 hidden">You appear to be using Redhat/Fedora/CentOS.</div>
 
   <table class="all-downloads mt-5">
     <tr class="border-bottom">
@@ -31,7 +28,6 @@ version: 0.9.0
     <tr class="border-bottom">
       <td>Debian/Ubuntu</td>
       <td>
-        <a class="dl-deb32" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-32bit-{{ site.client_version }}.deb">32 Bit</a> |
         <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">64 Bit</a>
       </td>
     </tr>

--- a/js/markets.js
+++ b/js/markets.js
@@ -55,8 +55,6 @@ function getTrades(pair){
                       jsonUrl = 'https://markets.bisq.network/api/trades?market=all&format=jsonpretty';
                       //jsonUrl = baseUrl+'/js/sample_data/trades_all.json';
 
-                      console.log(jsonUrl);
-
                       $.get( jsonUrl, function( data ) {
 
 
@@ -253,7 +251,7 @@ function buildData(jsonUrl){
       pair = 'btc';
 
       jsonUrl = "https://markets.bisq.network/api/volumes?basecurrency=btc&milliseconds=true&timestamp=no&format=jscallback&fillgaps=&callback=?&interval=day";
-      console.log("chart volumes: " + pair);
+      //console.log("chart volumes: " + pair);
       getTrades('all');
 
     }else{
@@ -262,12 +260,6 @@ function buildData(jsonUrl){
       getTrades(pair);
       getOffers(pair);
     }
-
-
-
-
-    console.log(jsonUrl);
-
 
     $.getJSON(jsonUrl, function (data) {
 

--- a/js/markets.js
+++ b/js/markets.js
@@ -116,7 +116,7 @@ function getTrades(pair){
                               $('<th>').text('Action'),
                               $('<th>').text('Price ('+buildTKR(pair)+')'),
                               $('<th>').text('Trade Size (BTC)'),
-                              $('<th>').text('Trade Size ('+buildTKR(pair)+')'),
+                              $('<th>').text('Trade Size ('+buildTKR(pair)+')')
                             ).appendTo('#trade-history-header');
 
                         }else{

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,64 +1,62 @@
-$(document).ready(function() {
+$( document ).ready( function() {
 
+    /**************************************************
+    detect os to show correct download links
+    **************************************************/
 
+    var uAgent = navigator.userAgent || navigator.vendor || window.opera;
+    var OSName = "Unknown OS";
 
+    if( uAgent.indexOf( "Win" ) > -1 ) {
+        OSName = "Windows";
+    } else if( uAgent.indexOf( "Mac" ) > -1 ) {
+        OSName = "MacOS";
+    } else if( uAgent.indexOf( "Linux" ) > -1 ) {
+        OSName = "Linux";
+    }
 
-  //OS detection
-  var OSName = "Unknown OS";
-  if (navigator.userAgent.indexOf("Win") != -1) OSName = "Windows";
-  else if (navigator.userAgent.indexOf("Mac") != -1) OSName = "MacOS";
-  else if (navigator.userAgent.indexOf("Linux") != -1) OSName = "Linux";
-  else if (navigator.userAgent.indexOf("X11") != -1) OSName = "UNIX";
+    //desktop
+    switch( OSName ) {
+        case "MacOS":
+            showOSDownloads( 'mac' );
+            break;
+        case "Windows":
+            showOSDownloads( 'win64' );
+            break;
+        case "Linux":
+            if( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1) {
+                showOSDownloads( 'deb64' );
+            } else if( uAgent.indexOf( "Redhat" ) > -1 || uAgent.indexOf( "CentOS" ) > -1 ||
+              uAgent.indexOf( "Fedora" ) > -1 ) {
+                showOSDownloads( 'rpm64' );
+            } else {
+                $( '.id-all').removeClass('hidden').addClass('shown');
+            }
+            break;
+    }
 
-  switch (OSName) {
-    case "MacOS":
-      $('.dl-mac').addClass('selected');
-      $('.id-mac').removeClass('hidden').addClass('shown');
-      break;
-    case "Windows":
-      $('.dl-win64').addClass('selected');
-      $('.id-win64').removeClass('hidden').addClass('shown');
-      break;
-    case "Linux":
-      var is64 = navigator.userAgent.indexOf("x86_64") != -1;
-      if (navigator.userAgent.indexOf("Ubuntu") != -1 || navigator.userAgent.indexOf("Debian") != -1) {
-        $('.dl-deb64').addClass('selected');
-        $('.id-deb64').removeClass('hidden').addClass('shown');
-      } else if (navigator.userAgent.indexOf("Redhat") != -1 ||
-        navigator.userAgent.indexOf("CentOS") != -1 ||
-        navigator.userAgent.indexOf("Fedora") != -1) {
-        $('.dl-rpm64').addClass('selected');
-        $('.id-rpm64').removeClass('hidden').addClass('shown');
-      } else {
-        $('.id-all').removeClass('hidden').addClass('shown');
-      }
-      break;
-  }
+    //mobile
+    if( /android/i.test( uAgent ) ) {
+        $( '.downloads-android' ).removeClass( 'hidden' ).addClass( 'shown' );
+        $( '.id-all').removeClass( 'hidden' ).addClass( 'shown' );
+    }
+    if( /iPad|iPhone|iPod/.test( uAgent ) && !window.MSStream ) {
+        $( '.downloads-ios' ).removeClass('hidden').addClass( 'shown' );
+        $( '.id-all' ).removeClass( 'hidden' ).addClass( 'shown' );
+    }
 
+    //add virtual pageview and event tracking for download attempts
+    $( '.dl-win64, .dl-mac, .dl-deb64' ).on( 'click', function() {
+        ga( 'send', 'pageview', location.pathname + 'release' );
+        ga( 'send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop() );
+    });
 
-  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
-  if (/windows phone/i.test(userAgent)) {
-    //nothing yet
-  }
-  if (/android/i.test(userAgent)) {
-    $('.downloads-android').removeClass('hidden').addClass('shown');
-    $('.id-all').removeClass('hidden').addClass('shown');
-  }
-  if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
-    $('.downloads-ios').removeClass('hidden').addClass('shown');
-    $('.id-all').removeClass('hidden').addClass('shown');
-  }
-
-
-
-  //console.log(OSName);
-
-  // add virtual pageview and event tracking for download attempts
-  $('.dl-win64, .dl-mac, .dl-deb64').click(function() {
-    ga('send', 'pageview', location.pathname + 'release');
-    ga('send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop());
-  });
-
+    //change dom to show downloads for the specific os
+    function showOSDownloads( os ) {
+        $( '.dl-' + os ).addClass( 'selected' );
+        $( '.id-' + os ).removeClass( 'hidden' ).addClass( 'shown' );
+        return;
+    }
 
 
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,46 +1,65 @@
 $( document ).ready( function() {
 
+
     /**************************************************
     detect os to show correct download links
     **************************************************/
 
+    var desktop = true;
     var uAgent = navigator.userAgent || navigator.vendor || window.opera;
-    var OSName = "Unknown OS";
+    var osName = "unknown";
+    var downloadLink = "<site_url_placeholder>/downloads";
 
     if( uAgent.indexOf( "Win" ) > -1 ) {
-        OSName = "Windows";
+        osName = "Windows";
+        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.exe";
     } else if( uAgent.indexOf( "Mac" ) > -1 ) {
-        OSName = "MacOS";
-    } else if( uAgent.indexOf( "Linux" ) > -1 ) {
-        OSName = "Linux";
-    }
-
-    //desktop
-    switch( OSName ) {
-        case "MacOS":
-            showOSDownloads( 'mac' );
-            break;
-        case "Windows":
-            showOSDownloads( 'win64' );
-            break;
-        case "Linux":
-            if( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1 ) {
-                showOSDownloads( 'deb64' );
-            } else {
-                $( '.id-all').removeClass('hidden').addClass('shown');
-            }
-            break;
+        osName = "MacOS";
+        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-<bisq_version_placeholder>.dmg";
+    } else if( uAgent.indexOf( "Linux" ) > -1 && ( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1 ) ) {
+        osName = "Linux";
+        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.deb";
     }
 
     //mobile
     if( /android/i.test( uAgent ) ) {
+        desktop = false;
         $( '.downloads-android' ).removeClass( 'hidden' ).addClass( 'shown' );
         $( '.id-all').removeClass( 'hidden' ).addClass( 'shown' );
     }
     if( /iPad|iPhone|iPod/.test( uAgent ) && !window.MSStream ) {
+        desktop = false;
         $( '.downloads-ios' ).removeClass('hidden').addClass( 'shown' );
         $( '.id-all' ).removeClass( 'hidden' ).addClass( 'shown' );
     }
+
+    //desktop
+    if( desktop ) {
+        switch( osName ) {
+            case "MacOS":
+                showOSDownloads( 'mac' );
+                break;
+            case "Windows":
+                showOSDownloads( 'win64' );
+                break;
+            case "Linux":
+                showOSDownloads( 'deb64' );
+                break;
+            default:
+                $( '.id-all').removeClass('hidden').addClass('shown');
+                break;
+        }
+    }
+
+    //capture click on currently-selected value in dropdown (otherwise
+    //link click event doesn't register on firefox)
+    $( 'button.selected-os-download' ).on( 'click', function(e) {
+        if( ( e.target.className ).indexOf( 'dl-' ) > -1 ) {
+            return;
+        } else {
+            serveDownload( $( e.currentTarget ).attr( 'data-bisq-version' ), $( e.currentTarget ).attr( 'data-site-url' ) );
+        }
+    });
 
     //add virtual pageview and event tracking for download attempts
     $( '.dl-win64, .dl-mac, .dl-deb64' ).on( 'click', function() {
@@ -55,6 +74,15 @@ $( document ).ready( function() {
         return;
     }
 
+    function serveDownload( bisqVersion, siteURL ) {
+        if( osName === 'unknown' ) {
+            downloadLink = downloadLink.replace( /<site_url_placeholder>/g, siteURL );
+        } else {
+            downloadLink = downloadLink.replace( /<bisq_version_placeholder>/g, bisqVersion );
+        }
+        location.href = downloadLink;
+        return;
+    }
 
 
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -16,25 +16,19 @@ $(document).ready(function() {
       $('.id-mac').removeClass('hidden').addClass('shown');
       break;
     case "Windows":
-      // if 64-bit
-      if (navigator.userAgent.indexOf("WOW64") != -1 || navigator.userAgent.indexOf("Win64") != -1) {
-        $('.dl-win64').addClass('selected');
-        $('.id-win64').removeClass('hidden').addClass('shown');
-      } else {
-        $('.dl-win32').addClass('selected');
-        $('.id-win32').removeClass('hidden').addClass('shown');
-      }
+      $('.dl-win64').addClass('selected');
+      $('.id-win64').removeClass('hidden').addClass('shown');
       break;
     case "Linux":
       var is64 = navigator.userAgent.indexOf("x86_64") != -1;
       if (navigator.userAgent.indexOf("Ubuntu") != -1 || navigator.userAgent.indexOf("Debian") != -1) {
-        $(is64 ? '.dl-deb64' : '.dl-deb32').addClass('selected');
-        $(is64 ? '.id-deb64' : '.id-deb32').removeClass('hidden').addClass('shown');
+        $('.dl-deb64').addClass('selected');
+        $('.id-deb64').removeClass('hidden').addClass('shown');
       } else if (navigator.userAgent.indexOf("Redhat") != -1 ||
         navigator.userAgent.indexOf("CentOS") != -1 ||
         navigator.userAgent.indexOf("Fedora") != -1) {
-        $(is64 ? '.dl-rpm64' : '.dl-rpm32').addClass('selected');
-        $(is64 ? '.id-rpm64' : '.id-rpm32').removeClass('hidden').addClass('shown');
+        $('.dl-rpm64').addClass('selected');
+        $('.id-rpm64').removeClass('hidden').addClass('shown');
       }
       break;
   }
@@ -58,7 +52,7 @@ $(document).ready(function() {
   //console.log(OSName);
 
   // add virtual pageview and event tracking for download attempts
-  $('.dl-win32, .dl-win64, .dl-mac, .dl-deb32, .dl-deb64').click(function() {
+  $('.dl-win64, .dl-mac, .dl-deb64').click(function() {
     ga('send', 'pageview', location.pathname + 'release');
     ga('send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop());
   });

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -11,13 +11,13 @@ $( document ).ready( function() {
     var downloadLink = "<site_url_placeholder>/downloads";
 
     if( uAgent.indexOf( "Win" ) > -1 ) {
-        osName = "Windows";
+        osName = "win64";
         downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.exe";
     } else if( uAgent.indexOf( "Mac" ) > -1 ) {
-        osName = "MacOS";
+        osName = "mac";
         downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-<bisq_version_placeholder>.dmg";
     } else if( uAgent.indexOf( "Linux" ) > -1 && ( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1 ) ) {
-        osName = "Linux";
+        osName = "deb64";
         downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.deb";
     }
 
@@ -35,19 +35,10 @@ $( document ).ready( function() {
 
     //desktop
     if( desktop ) {
-        switch( osName ) {
-            case "MacOS":
-                showOSDownloads( 'mac' );
-                break;
-            case "Windows":
-                showOSDownloads( 'win64' );
-                break;
-            case "Linux":
-                showOSDownloads( 'deb64' );
-                break;
-            default:
-                $( '.id-all').removeClass('hidden').addClass('shown');
-                break;
+        if( osName !== 'unknown' ) {
+            showOSDownloads( osName );
+        } else {
+            $( '.id-all').removeClass('hidden').addClass('shown');
         }
     }
 
@@ -61,10 +52,8 @@ $( document ).ready( function() {
         }
     });
 
-    //add virtual pageview and event tracking for download attempts
     $( '.dl-win64, .dl-mac, .dl-deb64' ).on( 'click', function() {
-        ga( 'send', 'pageview', location.pathname + 'release' );
-        ga( 'send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop() );
+        sendAnalytic( $(this).attr('class').split('-').pop().split(" ").shift() );
     });
 
     //change dom to show downloads for the specific os
@@ -74,16 +63,24 @@ $( document ).ready( function() {
         return;
     }
 
+    //for non-link clicks (i.e., the 'download for xx' text on closed dropdown)
     function serveDownload( bisqVersion, siteURL ) {
         if( osName === 'unknown' ) {
             downloadLink = downloadLink.replace( /<site_url_placeholder>/g, siteURL );
         } else {
             downloadLink = downloadLink.replace( /<bisq_version_placeholder>/g, bisqVersion );
+            sendAnalytic( osName );
         }
         location.href = downloadLink;
         return;
     }
 
+    //add virtual pageview and event tracking for download attempts
+    function sendAnalytic( platform ) {
+        ga( 'send', 'pageview', location.pathname + 'release' );
+        ga( 'send', 'event', 'Release Build', 'download', platform );
+        return;
+    }
 
 
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -29,6 +29,8 @@ $(document).ready(function() {
         navigator.userAgent.indexOf("Fedora") != -1) {
         $('.dl-rpm64').addClass('selected');
         $('.id-rpm64').removeClass('hidden').addClass('shown');
+      } else {
+        $('.id-all').removeClass('hidden').addClass('shown');
       }
       break;
   }

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -16,9 +16,13 @@ $(document).ready(function() {
       $('.id-mac').removeClass('hidden').addClass('shown');
       break;
     case "Windows":
+      // if 64-bit
       if (navigator.userAgent.indexOf("WOW64") != -1 || navigator.userAgent.indexOf("Win64") != -1) {
         $('.dl-win64').addClass('selected');
         $('.id-win64').removeClass('hidden').addClass('shown');
+      } else {
+        $('.dl-win32').addClass('selected');
+        $('.id-win32').removeClass('hidden').addClass('shown');
       }
       break;
     case "Linux":
@@ -54,7 +58,7 @@ $(document).ready(function() {
   //console.log(OSName);
 
   // add virtual pageview and event tracking for download attempts
-  $('.dl-win64, .dl-mac, .dl-deb32, .dl-deb64').click(function() {
+  $('.dl-win32, .dl-win64, .dl-mac, .dl-deb32, .dl-deb64').click(function() {
     ga('send', 'pageview', location.pathname + 'release');
     ga('send', 'event', 'Release Build', 'download', $(this).attr('class').split('-').pop());
   });

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -24,11 +24,8 @@ $( document ).ready( function() {
             showOSDownloads( 'win64' );
             break;
         case "Linux":
-            if( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1) {
+            if( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1 ) {
                 showOSDownloads( 'deb64' );
-            } else if( uAgent.indexOf( "Redhat" ) > -1 || uAgent.indexOf( "CentOS" ) > -1 ||
-              uAgent.indexOf( "Fedora" ) > -1 ) {
-                showOSDownloads( 'rpm64' );
             } else {
                 $( '.id-all').removeClass('hidden').addClass('shown');
             }


### PR DESCRIPTION
I found issues with download links:

- primary download links did work in firefox at all (!)
- ios showed ios and macos text at the same time
- inconsistent os highlighting in download menus (windows and macos particularly)
- add fallback text for non-windows-mac-linux users

Other notable changes:

- re-add analytics (the ga initialization script was missing before)
- remove all 32-bit links and rename 64-bit links (the '64 Bit' text from 3d23ce25b0ff8e080987076ddf467c0436720764 is gone with this PR so that should be an easy merge conflict)

So I spent some time yesterday reworking the code and UI for download links. While seemingly minor I figured it worth the time because getting users to download the Bisq software is probably our #1 goal for the website, and it should be a flawless experience.

@ripcurlx if you or someone with access to Analytics can verify that analytics are working again, that would be great. I was getting ga errors before, and I'm not getting them any more, but I can't be 100% sure events are actually being recorded on the server. 