### PR TITLE
Add URL redirects to GitHub content

### DIFF
--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -24,7 +24,7 @@
                                       Download for Windows
                                   </div>
                                   <div class="float-right">
-                                      <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+                                      <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
                                   </div>
                               </div>
 
@@ -35,7 +35,7 @@
                                       Download for Mac
                                   </div>
                                   <div class="float-right">
-                                      <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+                                      <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
                                   </div>
                               </div>
 
@@ -46,7 +46,7 @@
                                       Download for Debian/Ubuntu
                                   </div>
                                   <div class="float-right">
-                                      <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
+                                      <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
                                   </div>
                               </div>
 

--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -10,7 +10,7 @@
   <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w" /> Download for Windows
   <div class="float-right">
-    <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+    <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
   </div>
 </div>
 
@@ -19,7 +19,7 @@
   <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w" /> Download for Mac
   <div class="float-right">
-    <a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+    <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
   </div>
 </div>
 
@@ -28,7 +28,7 @@
   <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" /> Download for Debian/Ubuntu
   <div class="float-right">
-    <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
+    <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
   </div>
 </div>
 
@@ -44,15 +44,15 @@
   <img src="{{ site.url }}/images/icon-opensource-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-opensource-w.svg" class="os-icon os-icon-w" /> Source Code
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.zip">zip</a> |
-    <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></div>
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip">zip</a> |
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
   <img src="{{ site.url }}/images/icon-notes-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-notes-w.svg" class="os-icon os-icon-w" /> Release Notes
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">v{{ site.client_version }}</a>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}">v{{ site.client_version }}</a>
   </div>
 </div>
 
@@ -60,6 +60,6 @@
   <img src="{{ site.url }}/images/icon-verification-g.svg" class="os-icon os-icon-g" />
   <img src="{{ site.url }}/images/icon-verification-w.svg" class="os-icon os-icon-w" /> Verification
   <div class="float-right">
-    <a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">PGP signatures</a> |
-    <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></div>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}">PGP signatures</a> |
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></div>
 </div>

--- a/_redirects
+++ b/_redirects
@@ -101,6 +101,7 @@ https://bisq.io https://bisq.network 301
 
 /proposals/:id https://github.com/bisq-network/proposals/issues/:id 302
 /compensation/:id https://github.com/bisq-network/compensation/issues/:id 302
+/roles/:id https://github.com/bisq-network/roles/issues/:id 302
 
 /downloads/:version https://github.com/bisq-network/bisq/releases/tag/:version 302
 /downloads/:version/:filename https://github.com/bisq-network/bisq/releases/download/:version/:filename 302

--- a/_redirects
+++ b/_redirects
@@ -98,3 +98,12 @@ https://bisq.io https://bisq.network 301
 /release-stats http://www.somsubhra.com/github-release-stats/?username=bisq-network&repository=bisq 302
 
 /survey https://survey.io/survey/ddfaa 302
+
+/proposals/:id https://github.com/bisq-network/proposals/issues/:id 302
+/compensation/:id https://github.com/bisq-network/compensation/issues/:id 302
+
+/downloads/:version https://github.com/bisq-network/bisq/releases/tag/:version 302
+/downloads/:version/:filename https://github.com/bisq-network/bisq/releases/download/:version/:filename 302
+
+/downloads/archive/:version.zip https://github.com/bisq-network/bisq/archive/:version.zip 302
+/downloads/archive/:version.tar.gz https://github.com/bisq-network/bisq/archive/:version.tar.gz 302

--- a/_redirects
+++ b/_redirects
@@ -107,3 +107,6 @@ https://bisq.io https://bisq.network 301
 
 /downloads/archive/:version.zip https://github.com/bisq-network/bisq/archive/:version.zip 302
 /downloads/archive/:version.tar.gz https://github.com/bisq-network/bisq/archive/:version.tar.gz 302
+
+/source https://github.com/bisq-network 302
+/source/* https://github.com/bisq-network/:splat 302

--- a/downloads.html
+++ b/downloads.html
@@ -16,18 +16,18 @@ version: 0.9.3
     <tr class="border-bottom">
       <td>Windows</td>
       <td>
-        <a class="dl-win64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+        <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
       </td>
     </tr>
     <tr class="border-bottom">
       <td>Mac</td>
-      <td><a class="dl-mac" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+      <td><a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
       </td>
     </tr>
     <tr class="border-bottom">
       <td>Debian/Ubuntu</td>
       <td>
-        <a class="dl-deb64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
+        <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
       </td>
     </tr>
     <tr class="border-bottom">
@@ -36,17 +36,17 @@ version: 0.9.3
     </tr>
     <tr class="border-bottom">
       <td>Source Code</td>
-      <td><a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.zip">zip</a> |
-        <a href="https://github.com/bisq-network/bisq/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></td>
+      <td><a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip">zip</a> |
+        <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></td>
     </tr>
     <tr class="border-bottom">
       <td>Release Notes</td>
-      <td><a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">Release Notes for v{{ site.client_version }}</a></td>
+      <td><a href="https://bisq.network/downloads/v{{ site.client_version }}">Release Notes for v{{ site.client_version }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>Verification</td>
-      <td><a href="https://github.com/bisq-network/bisq/releases/tag/v{{ site.client_version }}">PGP signatures</a> |
-        <a href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></td>
+      <td><a href="https://bisq.network/downloads/v{{ site.client_version }}">PGP signatures</a> |
+        <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></td>
     </tr>
   </table>
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -12,13 +12,13 @@ $( document ).ready( function() {
 
     if( uAgent.indexOf( "Win" ) > -1 ) {
         osName = "win64";
-        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.exe";
+        downloadLink = "https://bisq.network/downloads/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.exe";
     } else if( uAgent.indexOf( "Mac" ) > -1 ) {
         osName = "mac";
-        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-<bisq_version_placeholder>.dmg";
+        downloadLink = "https://bisq.network/downloads/v<bisq_version_placeholder>/Bisq-<bisq_version_placeholder>.dmg";
     } else if( uAgent.indexOf( "Linux" ) > -1 && ( uAgent.indexOf( "Ubuntu" ) > -1 || uAgent.indexOf( "Debian" ) > -1 ) ) {
         osName = "deb64";
-        downloadLink = "https://github.com/bisq-network/bisq/releases/download/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.deb";
+        downloadLink = "https://bisq.network/downloads/v<bisq_version_placeholder>/Bisq-64bit-<bisq_version_placeholder>.deb";
     }
 
     //mobile


### PR DESCRIPTION
URL redirects for downloads, compensation requests, and
proposals; all of which currently go to GitHub.

See https://github.com/bisq-network/bisq/issues/2429