### PR TITLE
Fix site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Bisq
-url: "https://pedromvpg.github.io/bisq-website"
+url: "https://bisq.network"
 markdown: kramdown
 permalink: /blog/:title/
 livereload: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
           <h5 class="text-uppercase small grey">Resources</h5>
           <ul class="list-unstyled divide-3col" style="column-gap: 3rem;">
             <li>
-              <a href="https://docs.bisq.network/dao/phase-zero.html" target="_blank">Bisq&nbsp;DAO</a>
+              <a href="{{ site.url }}/dao" target="_blank">Bisq&nbsp;DAO</a>
             </li>
             <!--<li>
               <a href="{{ site.url }}/press">Press</a>


### PR DESCRIPTION
Wrong site URL was causing all main nav links to go to Pedro's github.io server. Couldn't properly evaluate changes beforehand because of all the noise on the master branch.