### PR TITLE
Make markets decimal handling more consistent

### DIFF
--- a/js/markets.js
+++ b/js/markets.js
@@ -71,7 +71,7 @@ function roundToSigFigs( num ) {
 
     if( num < parseFloat( .1 ) ) {
         precision = Math.floor( Math.log10( num ) ) + 1;
-        return num.toPrecision( ( 5 + precision ) < 1 ? 1 : ( 5 + precision ) );
+        return Number( num.toPrecision( ( 5 + precision ) < 1 ? 1 : ( 5 + precision ) ) ).toFixed( Math.abs(precision) + 1 );
     } else {
         precision = Math.floor( Math.log10( num/.0001 ) ) - 1;
         return num.toPrecision( precision );


### PR DESCRIPTION
Looks like JavaScript displays numbers with 6 digits or fewer after the decimal differently from those with more than 6 digits after the decimal.

This fix makes all small numbers appear more consistently, so that exponential notation does not show.

Addresses #139.