### PR TITLE
Change stats page graph subtitles

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -26,7 +26,7 @@ $( document ).ready( function() {
               y: 15
           },
           subtitle: {
-              text: 'As of March 2019',
+              text: 'Aggregate trading activity on the network',
               align: 'left'
           },
           xAxis: {
@@ -129,7 +129,7 @@ $( document ).ready( function() {
             y: 15
         },
         subtitle: {
-            text: 'As of March 2019',
+            text: 'Total BSQ issued net of BSQ burned for fees',
             align: 'left'
         },
         xAxis: {


### PR DESCRIPTION
To address @devinbileck's comment [here](https://github.com/bisq-network/bisq-website/pull/192#issuecomment-508804162). 

Having the current month in the subtitle isn't a great idea as it's not an obvious thing for a maintainer to update...and for users, it's not a very meaningful subtitle. 

I think these are better.