### PR TITLE
Update stats and download version

### DIFF
--- a/_data/strings_en.yml
+++ b/_data/strings_en.yml
@@ -303,26 +303,26 @@ stats:
   pBSQDistribution: Mainnet BSQ distribution is slated for April 2019.
   pTotalTrades: >
     <p class='stat-label'>Total Trades</p>
-    <p class='stat-figure'>32,318</p>
+    <p class='stat-figure'>34,535</p>
     <p class='stat-note'>Through June 2019</p>
   pDailyAverage: >
     <p class='stat-label'>Daily Average Trades</p>
-    <p class='stat-figure'>94</p>
-    <p class='stat-note'>For June 2019</p>
+    <p class='stat-figure'>72</p>
+    <p class='stat-note'>For July 2019</p>
   pSoftwareDownloads: >
     <p class='stat-label'>Software Downloads</p>
-    <p class='stat-figure'>13,723</p>
+    <p class='stat-figure'>17,968</p>
     <p class='stat-note'>For v1.1.2 (approximate)</p>
   pGithubContributors: >
     <p class='stat-label'>GitHub Contributors</p>
-    <p class='stat-figure'>172</p>
-    <p class='stat-note'>As of June 2019</p>
+    <p class='stat-figure'>182</p>
+    <p class='stat-note'>As of July 2019</p>
   pTwitterFollowers: >
     <p class='stat-label'>Twitter Followers</p>
-    <p class='stat-figure'>17,588</p>
-    <p class='stat-note'>As of June 2019</p>
+    <p class='stat-figure'>17,945</p>
+    <p class='stat-note'>As of July 2019</p>
   pSlackUsers: >
     <p class='stat-label'>Slack Users</p>
-    <p class='stat-figure'>1,183</p>
-    <p class='stat-note'>As of June 2019</p>
+    <p class='stat-figure'>1,258</p>
+    <p class='stat-note'>As of July 2019</p>
   pNetworkLoad: "<p class='monitor-note'>For P2P network load, Tor metrics, and other network data, please visit the <a href='https://monitor.bisq.network' target='_blank'>Bisq Network Monitor</a>.</p>"

--- a/_includes/main_nav_tr.html
+++ b/_includes/main_nav_tr.html
@@ -1,7 +1,14 @@
  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top pl-md-5 pr-md-5 pl-sm-3 pr-0">
 
-    <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
+    <div>
+      <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
 
+      <!-- Outdated translation tag-->
+      {% if page.lang == page.lang == "de" or page.lang="es" or "pt-PT" or page.lang == "zh-CN" %}
+        <span class="navbar-text" style="color: orange;">Outdated translation</span>
+      {% endif %}
+    </div>
+      
     <!-- Language selector for mobile -->
     {% if page.lang %}
     <div class="dropdown mobile-language-selector more-info-desktop">

--- a/_includes/main_nav_tr.html
+++ b/_includes/main_nav_tr.html
@@ -4,11 +4,11 @@
       <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
 
       <!-- Outdated translation tag-->
-      {% if page.lang == page.lang == "de" or page.lang="es" or "pt-PT" or page.lang == "zh-CN" %}
+      {% if page.lang == "de" or page.lang= "es" or "pt-PT" or page.lang == "zh-CN" %}
         <span class="navbar-text" style="color: orange;">Outdated translation</span>
       {% endif %}
     </div>
-      
+
     <!-- Language selector for mobile -->
     {% if page.lang %}
     <div class="dropdown mobile-language-selector more-info-desktop">

--- a/de/downloads.html
+++ b/de/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: de
 language: Deutsch

--- a/de/downloads.html
+++ b/de/downloads.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
+version: 1.1.5
 ref: downloads
 lang: de
 language: Deutsch

--- a/es/downloads.html
+++ b/es/downloads.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
+version: 1.1.5
 ref: downloads
 lang: es
 language: Español

--- a/es/downloads.html
+++ b/es/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: es
 language: Español

--- a/pt-PT/downloads.html
+++ b/pt-PT/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: pt-PT
 language: Português (PT)

--- a/zh-CN/downloads.html
+++ b/zh-CN/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: zh-CN
 language: 简体中文

--- a/zh-CN/downloads.html
+++ b/zh-CN/downloads.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
+version: 1.1.5
 ref: downloads
 lang: zh-CN
 language: 简体中文


### PR DESCRIPTION
@ripcurlx there are now 4 additional download pages on the website:
* /de/downloads.html
* /es/downloads.html
* /pt-PT/downloads.html
* /zh-CN/downloads.html

@m52go going forward, please also update the /_data/strings_en.yml when doing changes like updating the stats. The strings inside /_data/strings_en.yml are distributed into the following lists:
* footer
* homepage_content
* main_nav
* os_selector_options:
* dao
* downloads
* faq
* markets
* stats

I'll be setting up Transifex so that the "strings" resource updates when there are changes to  /_data/strings_en.yml.