### PR TITLE
Fix mobile notifications links on home page

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Bisq erhalten
   buttonToggle: Dropdown-Menü umschalten
   downloads: Downloads
-  androidNotificationsApp: Android Benachrichtigungs-App
-  iosNotificationApp: iOS Benachrichtigungs-App
+  androidNotificationsApp: Benachrichtigungs-App Android
+  iosNotificationApp: Benachrichtigungs-App iOS
   getStarted: Erste Schritte »
   runningWindows: Sie scheinen Windows zu benutzen
   runningMac: Sie scheinen einen Mac zu benutzen

--- a/_data/de.yml
+++ b/_data/de.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Bisq erhalten
   buttonToggle: Dropdown-Menü umschalten
   downloads: Downloads
-  androidNotificationsApp: Android Benachrichtigungs-App erhalten
-  iosNotificationApp: iOS Benachrichtigungs-App erhalten
+  androidNotificationsApp: Android Benachrichtigungs-App
+  iosNotificationApp: iOS Benachrichtigungs-App
   getStarted: Erste Schritte »
   runningWindows: Sie scheinen Windows zu benutzen
   runningMac: Sie scheinen einen Mac zu benutzen

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Obtener Bisq
   buttonToggle: Cambiar desplegable
   downloads: Descargas
-  androidNotificationsApp: Android app de Notificaciones
-  iosNotificationApp: iOS app de notificaciones
+  androidNotificationsApp: App de Notificaciones Android
+  iosNotificationApp: App de Notificaciones iOS
   getStarted: Comenzar »
   runningWindows: Parece que está ejecutando Windows
   runningMac: Parece que está ejecutando Mac

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Obtener Bisq
   buttonToggle: Cambiar desplegable
   downloads: Descargas
-  androidNotificationsApp: Obtener la app de Notificaciones Android
-  iosNotificationApp: Obtenter la app de notificaciones de iOS
+  androidNotificationsApp: Android app de Notificaciones
+  iosNotificationApp: iOS app de notificaciones
   getStarted: Comenzar »
   runningWindows: Parece que está ejecutando Windows
   runningMac: Parece que está ejecutando Mac

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Baixar Bisq
   buttonToggle: Toggle Dropdown
   downloads: Downloads
-  androidNotificationsApp: Baixar App de Notificação para Android
-  iosNotificationApp: Baixar App de Notificação para iOS
+  androidNotificationsApp: Android App de Notificação
+  iosNotificationApp: iOS App de Notificação
   getStarted: Começar »
   runningWindows: Você parece estar a utilizar Windows
   runningMac: Você parece estar a utilizar Mac

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -19,8 +19,8 @@ homepage_content:
   buttonGetBisq: Baixar Bisq
   buttonToggle: Toggle Dropdown
   downloads: Downloads
-  androidNotificationsApp: Android App de Notificação
-  iosNotificationApp: iOS App de Notificação
+  androidNotificationsApp: App de Notificação Android
+  iosNotificationApp: App de Notificação iOS
   getStarted: Começar »
   runningWindows: Você parece estar a utilizar Windows
   runningMac: Você parece estar a utilizar Mac

--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -98,7 +98,7 @@
                       </a>
 
 
-                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" rel="noopener" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'ios-notifications');">
+                      <a href="https://itunes.apple.com/us/app/bisq-mobile/id1424420411" target="_blank" rel="noopener" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'ios-notifications');">
                           <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
                           <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
                           Get iOS Notifications App

--- a/_includes/homepage_content_tr.html
+++ b/_includes/homepage_content_tr.html
@@ -99,7 +99,7 @@
                       </a>
 
 
-                      <a href="https://play.google.com/store/apps/details?id=com.joachimneumann.bisq" target="_blank" rel="noopener" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'ios-notifications');">
+                      <a href="https://itunes.apple.com/us/app/bisq-mobile/id1424420411" target="_blank" rel="noopener" class="downloads-ios hidden btn btn-lg btn-outline-secondary btn-icon hero-btn col-sm-12 col-md-12 col-lg-3 px-0 shadow-btn" onclick="ga('send', 'event', 'Jumbotron actions', 'download', 'ios-notifications');">
                           <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
                           <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
                           {{ item.iosNotificationApp }}


### PR DESCRIPTION
The iOS link on the home page was going to the Google Play store.

@huey735 I also shortened some of the texts for the mobile app download buttons. Could you check them to make sure they look ok? For Portugese for example, the text may not be gramatically perfect, but do you think it will work?

**Before**

`iosNotificationApp: Baixar App de Notificação para iOS`

![Screenshot from 2019-08-11 16-14-03](https://user-images.githubusercontent.com/735155/62839064-16108680-bc53-11e9-9424-1d92218efbae.png)

**After**

`iosNotificationApp: iOS App de Notificação`

![Screenshot from 2019-08-11 16-13-48](https://user-images.githubusercontent.com/735155/62839070-21fc4880-bc53-11e9-9c43-88c7cfb7079e.png)
