### PR TITLE
Remove extraneous `version` variable on downloads page

### DIFF
--- a/de/downloads.html
+++ b/de/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
 ref: downloads
 lang: de
 language: Deutsch

--- a/downloads.html
+++ b/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: en
 language: English

--- a/es/downloads.html
+++ b/es/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
 ref: downloads
 lang: es
 language: Español

--- a/pt-PT/downloads.html
+++ b/pt-PT/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.5
 ref: downloads
 lang: pt-PT
 language: Português (PT)

--- a/zh-CN/downloads.html
+++ b/zh-CN/downloads.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Bisq Downloads &lsaquo; Bisq - The decentralized Bitcoin exchange
-version: 1.1.4
 ref: downloads
 lang: zh-CN
 language: 简体中文


### PR DESCRIPTION
Variable wasn't being used.

FYI @ripcurlx...there's no need to update `download.html` any more for new releases. That page gets the software version from `_config.yml`.