### PR TITLE
Enable HSTS preload for bisq.network domain name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ sass:
   style: compressed
 webrick:
   headers:
-    Strict-Transport-Security: "max-age=31536000"
+    Strict-Transport-Security: "max-age=63072000; includeSubDomains; preload"
     X-XSS-Protection: "1; mode=block"
     X-Content-Type-Options: "nosniff"
     X-Frame-Options: "SAMEORIGIN"


### PR DESCRIPTION
HSTS is already enabled, but if we add "preload" we can add Bisq to https://hstspreload.org/