### PR TITLE
Redirect user to localized pages based on Accept-Language header

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -1,0 +1,24 @@
+- name: "English"
+  tag: "en"
+  enabled: No
+  accept_languages: ["en", "en-us", "en-au", "en-nz", "en-za", "en-bz", "en-tt"]
+- name: "Deutsch"
+  tag: "de"
+  enabled: Yes
+  accept_languages: ["de"]
+- name: "Español"
+  tag: "es"
+  enabled: Yes
+  accept_languages: ["es", "es-mx", "es-gt", "es-cr", "es-pa", "es-do", "es-ve", "es-co", "es-pe", "es-ar", "es-ec", "es-cl", "es-uy", "es-py", "es-bo", "es-sv", "es-hn", "es-ni", "es-pr"]
+- name: "日本語"
+  tag: "ja"
+  enabled: No
+  accept_languages: ["ja", "ja-jp"]
+- name: "Português"
+  tag: "pt-PT"
+  enabled: Yes
+  accept_languages: ["pt", "pt-PT"]
+- name: "简体中文"
+  tag: "zh-CN"
+  enabled: Yes
+  accept_languages: ["zh", "zh-CN"]

--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,120 @@
+---
+layout: null
+---
+# build-time generated redirects
+# redirect user based on Accept-Language setting
+# see https://www.netlify.com/docs/redirects/
+{% capture _redirects %}
+
+{% assign urls_sorted = site.pages | map: "url" | sort %}
+{% assign urls_filtered = "" | split: "," | pop %}
+
+{% for url in urls_sorted %}
+  # if you know a better way to strstr() feel free
+  {% assign first_two = url | slice: 1, 2 %}
+  {% assign first_three = url | slice: 1, 3 %}
+  {% assign first_four = url | slice: 1, 4 %}
+  {% assign first_five = url | slice: 1, 5 %}
+  {% assign first_six = url | slice: 1, 6 %}
+  {% assign first_seven = url | slice: 1, 7 %}
+
+  # don't redirect /404
+  {% if first_three == "404" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /css
+  {% if first_three == "css" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /blog
+  {% if first_four == "blog" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /press
+  {% if first_five == "press" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /robots.txt
+  {% if first_six == "robots" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /roadmap
+  {% if first_seven == "roadmap" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /sitemap
+  {% if first_seven == "sitemap" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /_redirects
+  {% if first_six == "_redir" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /redirects.json
+  {% if first_five == "redir" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect /funding-voices
+  {% if first_seven == "funding" %}
+    {% continue %}
+  {% endif %}
+
+  # don't redirect language-specific URIs
+  {% assign is_lang = 0 %}
+  {% for language in site.data.languages %}
+
+    # for de
+    {% if first_two == language.tag %}
+      {% assign is_lang = 1 %}
+      {% continue %}
+    {% endif %}
+
+    # for pt-PT
+    {% if first_five == language.tag %}
+      {% assign is_lang = 1 %}
+      {% continue %}
+    {% endif %}
+
+  {% endfor %}
+
+  # add URL to redirect list
+  {% if is_lang == 0 %}
+    {% assign urls_filtered = urls_filtered | push: url %}
+  {% endif %}
+{% endfor %}
+
+{% assign redirects = "" | split: "," | pop %}
+
+{% for url in urls_filtered %}
+  {% for language in site.data.languages %}
+    {% if language.enabled %}
+      {% for accept_language in language.accept_languages %}
+
+        {% capture redirect %}{{url}}  /{{language.tag}}{{url}}  302  Language={{accept_language}}{% endcapture %}
+        {% assign redirects = redirects | push: redirect %}
+
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+
+{% capture newline %}
+{% endcapture %}
+
+{% endcapture %}
+{{redirects | join: newline}}
+
 #
-# See https://www.netlify.com/docs/redirects/
+# static redirects
 #
 
 # bitsquare.io


### PR DESCRIPTION
Needs testing on netlify before merging to production site. Example test cases:

1) `curl -i -H 'Accept-Language: en' https://bisq.network|head -1` should 200 and serve / as normal
2) `curl -i -H 'Accept-Language: es' https://bisq.network/|head -15` should 302 with Location: /es/
3) `curl -i -H 'Accept-Language: es' https://bisq.network/dao/|head -15` should 302 with Location: /es/dao/