### PR TITLE
Homepage update - adding URLs to "Download for x"

### DIFF
--- a/_includes/homepage_content.html
+++ b/_includes/homepage_content.html
@@ -21,7 +21,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
-                                      Download for Windows
+                                      <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">Download for Windows</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
@@ -32,7 +32,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
-                                      Download for Mac
+                                      <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">Download for Mac</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
@@ -43,7 +43,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
-                                      Download for Debian/Ubuntu
+                                      <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">Download for Debian/Ubuntu</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
@@ -54,7 +54,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-fedora-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-fedora-w.svg" class="os-icon os-icon-w">
-                                      Download for Red Hat/Fedora
+                                      <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">Download for Red Hat/Fedora</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>

--- a/_includes/homepage_content_tr.html
+++ b/_includes/homepage_content_tr.html
@@ -21,7 +21,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-windows-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-windows-w.svg" class="os-icon os-icon-w">
-                                      {{ item.buttonWindows }}
+                                      <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">{{ item.buttonWindows }}</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
@@ -32,7 +32,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-apple-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-apple-w.svg" class="os-icon os-icon-w">
-                                      {{ item.buttonMac }}
+                                      <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">{{ item.buttonMac }}</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
@@ -43,7 +43,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-ubuntu-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-ubuntu-w.svg" class="os-icon os-icon-w">
-                                      {{ item.buttonDebian }}
+                                      <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">{{ item.buttonDebian }}</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
@@ -54,7 +54,7 @@
                                   <div class="float-left">
                                       <img src="{{ site.url }}/images/icon-fedora-g.svg" class="os-icon os-icon-g">
                                       <img src="{{ site.url }}/images/icon-fedora-w.svg" class="os-icon os-icon-w">
-                                      {{ item.buttonRedHat }}
+                                      <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">{{ item.buttonRedHat }}</a>
                                   </div>
                                   <div class="float-right">
                                       <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>


### PR DESCRIPTION
When I very first viewed the homepage, I clicked the "Download for Windows" button ten times before realizing that it's not linked with any URL. This update fixes that.