### PR TITLE
Add outdated_translation variable

### DIFF
--- a/_includes/main_nav_tr.html
+++ b/_includes/main_nav_tr.html
@@ -1,8 +1,6 @@
  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top pl-md-5 pr-md-5 pl-sm-3 pr-0">
 
-   <div>
-     <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
-   </div>
+    <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
 
     <!-- Language selector for mobile -->
     {% if page.lang %}

--- a/_includes/main_nav_tr.html
+++ b/_includes/main_nav_tr.html
@@ -2,11 +2,6 @@
 
    <div>
      <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
-
-     <!-- Outdated translation alert tool tag-->
-     {% if page.outdated_translation %}
-       <span class="navbar-text" style="color: orange;">Outdated translation</span>
-     {% endif %}
    </div>
 
     <!-- Language selector for mobile -->

--- a/_includes/main_nav_tr.html
+++ b/_includes/main_nav_tr.html
@@ -1,6 +1,13 @@
  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top pl-md-5 pr-md-5 pl-sm-3 pr-0">
 
-    <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
+   <div>
+     <a class="navbar-brand" href="{{ site.url }}/{{ page.lang }}/"><img src="{{ site.url }}/images/bisq-logo.svg" height="30"/></a>
+
+     <!-- Outdated translation alert tool tag-->
+     {% if page.outdated_translation %}
+       <span class="navbar-text" style="color: orange;">Outdated translation</span>
+     {% endif %}
+   </div>
 
     <!-- Language selector for mobile -->
     {% if page.lang %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,7 @@ layout: default
       <!-- Outdated translation alert tool tag-->
       <div class="col-md-12 order-md-1 text-md-left">
         {% if page.outdated_translation %}
-          <a class="outdatedTranslation" href="https://www.transifex.com/bisq/bisq-website/">Outdated translation - Help us to improve it!</a>
+          <p class="text-muted">⚠ This page contains some outdated translations. Help us improve <a href="https://www.transifex.com/bisq/bisq-website/">here</a>!</p>
         {% endif %}
       </div>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,6 +4,13 @@ layout: default
 
 <div class="container pb-5 mb-5">
     <div class="row align-items-center">
+      <!-- Outdated translation alert tool tag-->
+      <div class="col-md-12 order-md-1 text-md-left">
+        {% if page.outdated_translation %}
+          <a style="color: orange;" href="https://www.transifex.com/bisq/bisq-website/">Outdated translation - Help us to improve it!</a>
+        {% endif %}
+      </div>
+      
       <!-- <div class="{% if page.url == '/community/' %}col-md-12{% else %}col-md-8{% endif %} order-md-1 text-md-left pr-md-5"> -->
       <div class="col-md-12 order-md-1 text-md-left">
          {{ content }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,10 +7,10 @@ layout: default
       <!-- Outdated translation alert tool tag-->
       <div class="col-md-12 order-md-1 text-md-left">
         {% if page.outdated_translation %}
-          <a style="color: orange;" href="https://www.transifex.com/bisq/bisq-website/">Outdated translation - Help us to improve it!</a>
+          <a class="outdatedTranslation" href="https://www.transifex.com/bisq/bisq-website/">Outdated translation - Help us to improve it!</a>
         {% endif %}
       </div>
-      
+
       <!-- <div class="{% if page.url == '/community/' %}col-md-12{% else %}col-md-8{% endif %} order-md-1 text-md-left pr-md-5"> -->
       <div class="col-md-12 order-md-1 text-md-left">
          {{ content }}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -12,6 +12,19 @@ body {
   letter-spacing: 0.03rem;
 }
 
+.outdatedTranslation {
+  color: black;
+  background-color: orange;
+  font-weight: bold;
+  padding: 4px;
+
+}
+
+.outdatedTranslation:hover {
+  text-decoration: underline;
+  color: blue;
+}
+
 strong {
     font-weight: 700;
 }

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -12,19 +12,6 @@ body {
   letter-spacing: 0.03rem;
 }
 
-.outdatedTranslation {
-  color: black;
-  background-color: orange;
-  font-weight: bold;
-  padding: 4px;
-
-}
-
-.outdatedTranslation:hover {
-  text-decoration: underline;
-  color: blue;
-}
-
 strong {
     font-weight: 700;
 }

--- a/de/community.md
+++ b/de/community.md
@@ -4,6 +4,7 @@ title: Community &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: community
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 # Community
 {: .mb-5}

--- a/de/dao.html
+++ b/de/dao.html
@@ -4,6 +4,7 @@ title: The DAO &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: dao
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 
 

--- a/de/downloads.html
+++ b/de/downloads.html
@@ -5,6 +5,7 @@ version: 1.1.4
 ref: downloads
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].downloads %}
 <h1>Bisq Downloads</h1>

--- a/de/faq.html
+++ b/de/faq.html
@@ -4,6 +4,7 @@ title: FAQ &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: faq
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].faq %}
 <h1>{{ item.hFAQ }}</h1>

--- a/de/index.md
+++ b/de/index.md
@@ -5,6 +5,7 @@ banner: /images/bitsquare-home2.jpg
 ref: index
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 
 <iframe src="https://www.youtube-nocookie.com/embed/jj4x4x1OlAY?rel=0&amp;showinfo=0" width="704" height="396" frameborder="0"  allowfullscreen="allowfullscreen" allow="autoplay; encrypted-media"></iframe>

--- a/de/markets.html
+++ b/de/markets.html
@@ -4,6 +4,7 @@ title: Bisq Markets &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: markets
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 <!-- <h1>Bisq Markets</h1> -->
 

--- a/de/stats.html
+++ b/de/stats.html
@@ -4,6 +4,7 @@ title: Network Stats &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: stats
 lang: de
 language: Deutsch
+outdated_translation: true
 ---
 
 <link href="{{ '/css/chosen.css' | relative_url }}" rel="stylesheet">

--- a/de/vision.md
+++ b/de/vision.md
@@ -4,6 +4,7 @@ title: Vision &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: vision
 lang: de
 language: Deutsch
+outdated_translation: false
 ---
 # Vision
 {: .mb-5}

--- a/es/community.md
+++ b/es/community.md
@@ -4,6 +4,7 @@ title: Comunidad &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: community
 lang: es
 language: Español
+outdated_translation: false
 ---
 # Comunidad
 {: .mb-5}

--- a/es/dao.html
+++ b/es/dao.html
@@ -4,6 +4,7 @@ title: The DAO &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: dao
 lang: es
 language: Español
+outdated_translation: false
 ---
 
 

--- a/es/downloads.html
+++ b/es/downloads.html
@@ -5,6 +5,7 @@ version: 1.1.4
 ref: downloads
 lang: es
 language: Español
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].downloads %}
 <h1>Bisq Downloads</h1>

--- a/es/faq.html
+++ b/es/faq.html
@@ -4,6 +4,7 @@ title: FAQ &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: faq
 lang: es
 language: Español
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].faq %}
 <h1>{{ item.hFAQ }}</h1>

--- a/es/index.md
+++ b/es/index.md
@@ -5,6 +5,7 @@ banner: /images/bitsquare-home2.jpg
 ref: index
 lang: es
 language: Español
+outdated_translation: false
 ---
 
 <iframe src="https://www.youtube-nocookie.com/embed/jj4x4x1OlAY?rel=0&amp;showinfo=0" width="704" height="396" frameborder="0"  allowfullscreen="allowfullscreen" allow="autoplay; encrypted-media"></iframe>

--- a/es/markets.html
+++ b/es/markets.html
@@ -4,6 +4,7 @@ title: Bisq Markets &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: markets
 lang: es
 language: Español
+outdated_translation: false
 ---
 <!-- <h1>Bisq Markets</h1> -->
 

--- a/es/stats.html
+++ b/es/stats.html
@@ -4,6 +4,7 @@ title: Network Stats &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: stats
 lang: es
 language: Español
+outdated_translation: true
 ---
 
 <link href="{{ '/css/chosen.css' | relative_url }}" rel="stylesheet">

--- a/es/vision.md
+++ b/es/vision.md
@@ -4,6 +4,7 @@ title: Vision &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: vision
 lang: es
 language: Español
+outdated_translation: false
 ---
 # Visión
 {: .mb-5}

--- a/pt-PT/community.md
+++ b/pt-PT/community.md
@@ -4,6 +4,7 @@ title: Community &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: community
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 # Comunidade
 {: .mb-5}

--- a/pt-PT/dao.html
+++ b/pt-PT/dao.html
@@ -4,6 +4,7 @@ title: The DAO &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: dao
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 
 

--- a/pt-PT/downloads.html
+++ b/pt-PT/downloads.html
@@ -5,6 +5,7 @@ version: 1.1.5
 ref: downloads
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].downloads %}
 <h1>Bisq Downloads</h1>

--- a/pt-PT/faq.html
+++ b/pt-PT/faq.html
@@ -4,6 +4,7 @@ title: FAQ &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: faq
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].faq %}
 <h1>{{ item.hFAQ }}</h1>

--- a/pt-PT/index.md
+++ b/pt-PT/index.md
@@ -5,6 +5,7 @@ banner: /images/bitsquare-home2.jpg
 ref: index
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 
 <iframe src="https://www.youtube-nocookie.com/embed/jj4x4x1OlAY?rel=0&amp;showinfo=0" width="704" height="396" frameborder="0"  allowfullscreen="allowfullscreen" allow="autoplay; encrypted-media"></iframe>

--- a/pt-PT/markets.html
+++ b/pt-PT/markets.html
@@ -4,6 +4,7 @@ title: Bisq Markets &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: markets
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 <!-- <h1>Bisq Markets</h1> -->
 

--- a/pt-PT/stats.html
+++ b/pt-PT/stats.html
@@ -4,6 +4,7 @@ title: Network Stats &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: stats
 lang: pt-PT
 language: Português (PT)
+outdated_translation: true
 ---
 
 <link href="{{ '/css/chosen.css' | relative_url }}" rel="stylesheet">

--- a/pt-PT/vision.md
+++ b/pt-PT/vision.md
@@ -4,6 +4,7 @@ title: Vision &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: vision
 lang: pt-PT
 language: Português (PT)
+outdated_translation: false
 ---
 # Visão
 {: .mb-5}

--- a/zh-CN/community.md
+++ b/zh-CN/community.md
@@ -4,6 +4,7 @@ title: Bisq &lsaquo; 社区 - 去中心化比特币交易
 ref: community
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 # 社区
 {: .mb-5}

--- a/zh-CN/dao.html
+++ b/zh-CN/dao.html
@@ -4,6 +4,7 @@ title: The DAO &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: dao
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 
 

--- a/zh-CN/downloads.html
+++ b/zh-CN/downloads.html
@@ -5,6 +5,7 @@ version: 1.1.4
 ref: downloads
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].downloads %}
 <h1>Bisq Downloads</h1>

--- a/zh-CN/faq.html
+++ b/zh-CN/faq.html
@@ -4,6 +4,7 @@ title: FAQ &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: faq
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 {% assign item = site.data[page.lang].faq %}
 <h1>{{ item.hFAQ }}</h1>

--- a/zh-CN/index.md
+++ b/zh-CN/index.md
@@ -5,6 +5,7 @@ banner: /images/bitsquare-home2.jpg
 ref: index
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 
 <iframe src="https://www.youtube-nocookie.com/embed/jj4x4x1OlAY?rel=0&amp;showinfo=0" width="704" height="396" frameborder="0"  allowfullscreen="allowfullscreen" allow="autoplay; encrypted-media"></iframe>

--- a/zh-CN/markets.html
+++ b/zh-CN/markets.html
@@ -4,6 +4,7 @@ title: Bisq Markets &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: markets
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 <!-- <h1>Bisq Markets</h1> -->
 

--- a/zh-CN/stats.html
+++ b/zh-CN/stats.html
@@ -4,6 +4,7 @@ title: Network Stats &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: stats
 lang: zh-CN
 language: 简体中文
+outdated_translation: true
 ---
 
 <link href="{{ '/css/chosen.css' | relative_url }}" rel="stylesheet">

--- a/zh-CN/vision.md
+++ b/zh-CN/vision.md
@@ -4,6 +4,7 @@ title: Vision &lsaquo; Bisq - The decentralized Bitcoin exchange
 ref: vision
 lang: zh-CN
 language: 简体中文
+outdated_translation: false
 ---
 # 愿景
 {: .mb-5}


### PR DESCRIPTION
On @m52go's advice I changed the construction of the outdated
translation alert tool to be spefic to the page instead of
the language. I added a "outdated_translation" variable to
the front matter of the relevant translated pages. They'll
have the values 'true' or 'false' according to the state.