### PR TITLE
Refactored "Statistics" page to make it more i18n friendly

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -301,16 +301,13 @@ stats:
   hNetworkStats: Netzwerk-Statistiken
   pSeeMarkets: "<p>Auf der <a href='https://bisq.network/markets'>Märkte Seite</a> finden Sie das Volumen je nach Währung.</p>"
   pBSQDistribution: Die Mainnet BSQ-Ausgabe ist für April 2019 geplant.
-  pTotalTrades: >
-    <p class='stat-label'>Trades insgesamt</p> <p class='stat-figure'>32.318</p> <p class='stat-note'>Bis Juni 2019</p>
-  pDailyAverage: >
-    <p class='stat-label'>Täglich durchschnittliche Trades</p> <p class='stat-figure'>94</p> <p class='stat-note'>Für Juni 2019</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>Software Downloads</p> <p class='stat-figure'>13.723</p> <p class='stat-note'>Für v1.1.2 (ungefähr)</p>
-  pGithubContributors: >
-    <p class='stat-label'>GitHub Mitarbeiter</p> <p class='stat-figure'>172</p> <p class='stat-note'>Stand: Juni 2019</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Twitter Follower</p> <p class='stat-figure'>17588</p> <p class='stat-note'>Stand: Juni 2019</p>
-  pSlackUsers: >
-    <p class='stat-label'>Slack User</p> <p class='stat-figure'>1.183</p> <p class='stat-note'>Stand: Juni 2019</p>
+  pTotalTrades: Trades insgesamt
+  pTotalDate: Während des letzten Monats
+  pDailyAverageTrade: Täglich durchschnittliche Trades
+  pSoftwareDownloads: Software Downloads
+  pSoftwareDownloadsVersion: Für v1.1.2 (ungefähr)
+  pGithubContributors: GitHub Mitarbeiter
+  pToDate: Bis Ende letzten Monats
+  pTwitterFollowers: Twitter Follower
+  pSlackUsers: Slack User
   pNetworkLoad: "<p class='monitor-note'>Für die P2P-Netzwerklast, Tor-Metriken und andere Netzwerkdaten besuchen Sie bitte den <a href='https://monitor.bisq.network' target='_blank'>Bisq Network Monitor</a>.</p>"

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -329,16 +329,13 @@ stats:
   hNetworkStats: Estado de red
   pSeeMarkets: "<p>Ver la <a href='localhost:4001/markets'>página de Mercados</a> para el volumen por moneda.</p>"
   pBSQDistribution: La distribución de BSQ en la red principal fue el 15 de Abril de 2019.
-  pTotalTrades: >
-    <p class='stat-label'>Intercambios totales</p> <p class='stat-figure'>25,585</p> <p class='stat-note'>en Marzo de 2019</p>
-  pDailyAverage: >
-    <p class='stat-label'>Promedio diario de operaciones</p> <p class='stat-figure'>94</p> <p class='stat-note'>Para Junio 2019</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>Las descargas de software fueron</p> <p class='stat-figure'>13,723</p> <p class='stat-note'>para la versión v1.1.2 (approximado)</p>
-  pGithubContributors: >
-    <p class='stat-label'>Contribuyentes de GitHub</p> <p class='stat-figure'>172</p> <p class='stat-note'>en Junio de 2019</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Seguidores de Twitter</p> <p class='stat-figure'>17,588</p> <p class='stat-note'>en Junio de 2019</p>
-  pSlackUsers: >
-    <p class='stat-label'>Usuarios de Slack</p> <p class='stat-figure'>1,183</p> <p class='stat-note'>en Junio de 2019</p>
+  pTotalTrades: Intercambios totales
+  pTotalDate: Durante el mes pasado
+  pDailyAverageTrade: Promedio diario de operaciones
+  pSoftwareDownloads: Las descargas de software fueron
+  pSoftwareDownloadsVersion: para la versión v1.1.2 (approximado)
+  pGithubContributors: Contribuyentes de GitHub
+  pToDate: Hasta el mes pasado
+  pTwitterFollowers: Seguidores de Twitter
+  pSlackUsers: Usuarios de Slack
   pNetworkLoad: "<p class='monitor-note'>Para carga de la red P2P, métricas de Tor y otros datos de red, por favor visite el<a href='https://monitor.bisq.network' target='_blank'>Monitor de Red Bisq</a>.</p>"

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -301,16 +301,13 @@ stats:
   hNetworkStats: Stats du réseau
   pSeeMarkets: "<p>Voir <a href='https://bisq.network/markets'>la page des marchés</a> pour le volume par devise.</p>"
   pBSQDistribution: La distribution des BSQ sur le Mainnet est prévue pour avril 2019.
-  pTotalTrades: >
-    <p class='stat-label'>Total des transactions</p> <p class='stat-figure'>32,318</p> <p class='stat-note'>Pour Juin 2019</p>
-  pDailyAverage: >
-    <p class='stat-label'>Moyenne journalière des transactions</p> <p class='stat-figure'>94</p> <p class='stat-note'>En Juin 2019</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>Téléchargements du logiciel</p> <p class='stat-figure'>13,723</p> <p class='stat-note'>For v1.1.2 (approximation)</p>
-  pGithubContributors: >
-    <p class='stat-label'>Contributeurs GitHub </p> <p class='stat-figure'>172</p> <p class='stat-note'>En Juin 2019</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Followers sur Twitter </p> <p class='stat-figure'>17,588</p> <p class='stat-note'>En Juin 2019</p>
-  pSlackUsers: >
-    <p class='stat-label'> Utilisateurs Slack</p> <p class='stat-figure'>1,183</p> <p class='stat-note'>En Juin 2019</p>
+  pTotalTrades: Total des transactions
+  pTotalDate: Au cours du mois dernier
+  pDailyAverageTrade: Moyenne journalière des transactions
+  pSoftwareDownloads: Téléchargements du logiciel
+  pSoftwareDownloadsVersion: For v1.1.2 (approximation)
+  pGithubContributors: Contributeurs GitHub
+  pToDate: Depuis le mois dernier
+  pTwitterFollowers: Followers sur Twitter
+  pSlackUsers: Utilisateurs Slack
   pNetworkLoad: "<p class='monitor-note'>Pour connaître la sollicitation du réseau P2P, les métriques Tor et d'autres données réseau, veuillez visiter le site Web du <a href='https://monitor.bisq.network' target='_blank'>contrôleur de réseau Bisq</a>.</p>"

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -308,16 +308,13 @@ stats:
   hNetworkStats: Estatisticas da Rede
   pSeeMarkets: "<p>Confira a <a href='https://bisq.network/markets'>página de Mercados</a> para ver volume por moeda.</p>"
   pBSQDistribution: A distribuição de BSQ na Mainnet está prevista para Abril 2019
-  pTotalTrades: >
-    <p class='stat-label'>Todos os Negócios</p> <p class='stat-figure'>32,318</p> <p class='stat-note'>Durante Junho 2019</p>
-  pDailyAverage: >
-    <p class='stat-label'>Média de negócios por dia</p> <p class='stat-figure'>94</p> <p class='stat-note'>Durante Junho 2019</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>Downloads do Software</p> <p class='stat-figure'>13,723</p> <p class='stat-note'>Para v1.1.2 (aproximativa)</p>
-  pGithubContributors: >
-    <p class='stat-label'>Contribuintes no GitHub</p> <p class='stat-figure'>172</p> <p class='stat-note'>Em Junho 2019</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Seguidores no Twitter</p> <p class='stat-figure'>17,588</p> <p class='stat-note'>Em Junho  2019</p>
-  pSlackUsers: >
-    <p class='stat-label'>Utilizadores do Slack </p> <p class='stat-figure'>1,183</p> <p class='stat-note'>Em Junho  2019</p>
+  pTotalTrades: Todos os Negócios
+  pTotalDate: Durante o mês passado
+  pDailyAverageTrade: Média de negócios por dia
+  pSoftwareDownloads: Downloads do Software
+  pSoftwareDownloadsVersion: Para v1.1.2 (aproximativa)
+  pGithubContributors: Contribuintes no GitHub
+  pToDate: Até o mês passado
+  pTwitterFollowers: Seguidores no Twitter
+  pSlackUsers: Utilizadores do Slack
   pNetworkLoad: "<p class='monitor-note'>Para a carga da rede P2P, métricas do Tor, e outros dados da rede, por favor visite o <a href='https://monitor.bisq.network' target='_blank'>Monitor da Rede do Bisq</a>.</p>"

--- a/_data/strings_en.yml
+++ b/_data/strings_en.yml
@@ -301,28 +301,13 @@ stats:
   hNetworkStats: Network Stats
   pSeeMarkets: "<p>See <a href='https://bisq.network/markets'>Markets page</a> for volume by currency.</p>"
   pBSQDistribution: The mainnet <a href='https://docs.bisq.network/dao-user-reference.html#bsq-genesis-distribution' target='_blank'>BSQ genesis distribution</a> took place in April 2019.
-  pTotalTrades: >
-    <p class='stat-label'>Total Trades</p>
-    <p class='stat-figure'>37,570</p>
-    <p class='stat-note'>Through August 2019</p>
-  pDailyAverage: >
-    <p class='stat-label'>Daily Average Trades</p>
-    <p class='stat-figure'>98</p>
-    <p class='stat-note'>For August 2019</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>Software Downloads</p>
-    <p class='stat-figure'>10,381</p>
-    <p class='stat-note'>For v1.1.5 (approximate)</p>
-  pGithubContributors: >
-    <p class='stat-label'>GitHub Contributors</p>
-    <p class='stat-figure'>188</p>
-    <p class='stat-note'>As of August 2019</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Twitter Followers</p>
-    <p class='stat-figure'>18,364</p>
-    <p class='stat-note'>As of August 2019</p>
-  pSlackUsers: >
-    <p class='stat-label'>Slack Users</p>
-    <p class='stat-figure'>1,327</p>
-    <p class='stat-note'>As of August 2019</p>
+  pTotalTrades: Total Trades
+  pTotalDate: Through last month
+  pDailyAverageTrade: Daily Average Trades
+  pSoftwareDownloads: Software Downloads
+  pSoftwareDownloadsVersion: For v1.1.2 (approximate)
+  pGithubContributors: GitHub Contributors
+  pToDate: As of last month
+  pTwitterFollowers: Twitter Followers
+  pSlackUsers: Slack Users
   pNetworkLoad: "<p class='monitor-note'>For P2P network load, Tor metrics, and other network data, please visit the <a href='https://monitor.bisq.network' target='_blank'>Bisq Network Monitor</a>.</p>"

--- a/_data/zh-CN.yml
+++ b/_data/zh-CN.yml
@@ -331,16 +331,13 @@ stats:
   hNetworkStats: 网络状况
   pSeeMarkets: "<p>按货币计算的成交量见<a href='https://bisq.network/markets'>市场页面</a>。</p>"
   pBSQDistribution: 核心网络 BSQ 计划于2019年4月发布。
-  pTotalTrades: >
-    <p class='stat-label'>总交易数</p><p class='stat-figure'> 32,318 </p><p class='stat-note'>截止2019年6月</p>
-  pDailyAverage: >
-    <p class='stat-label'>每日交易数</p><p class='stat-figure'> 94 </p><p class='stat-note'> 2019 年 6 月</p>
-  pSoftwareDownloads: >
-    <p class='stat-label'>软件下载数</p><p class='stat-figure'> 13,723 </p><p class='stat-note'>在 v1.1.2（近似数）</p>
-  pGithubContributors: >
-    <p class='stat-label'>GitHub 贡献者</p><p class='stat-figure'> 172 </p><p class='stat-note'>截至2019年6月</p>
-  pTwitterFollowers: >
-    <p class='stat-label'>Twitter 粉丝数</p><p class='stat-figure'> 17,588 </p><p class='stat-note'>截至2019年6月</p>
-  pSlackUsers: >
-    <p class='stat-label'>Slack 用户数</p><p class='stat-figure'>1,183</p><p class='stat-note'>截至2019年6月</p>
+  pTotalTrades: 总交易数
+  pTotalDate: 上月数据
+  pDailyAverageTrade: 每日交易数
+  pSoftwareDownloads: 软件下载数<
+  pSoftwareDownloadsVersion: 在 v1.1.2（近似数）
+  pGithubContributors: GitHub 贡献者
+  pToDate: 截止上月
+  pTwitterFollowers: Twitter 粉丝数
+  pSlackUsers: Slack 用户数
   pNetworkLoad: "<p class='monitor-note'>有关 P2P 网络负载情况、Tor 指标和其他网络数据，请访问<a href='https://monitor.bisq.network' target='_blank'>Bisq 网络状况监控</a>。</p>"

--- a/_includes/statistics_data.html
+++ b/_includes/statistics_data.html
@@ -1,0 +1,36 @@
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pTotalTrades}}</p>
+    <p class='stat-figure'>37,570</p>
+    <p class='stat-note'>{{item.pTotalDate}}</p>
+</div>
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pDailyAverageTrade}}</p>
+    <p class='stat-figure'>98</p>
+    <p class='stat-note'>{{item.pTotalDate}}</p>
+</div>
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pSoftwareDownloads}}</p>
+    <p class='stat-figure'>10,381</p>
+    <p class='stat-note'>{{item.pSoftwareDownloadsVersion}}</p>
+</div>
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pGithubContributors}}</p>
+    <p class='stat-figure'>188</p>
+    <p class='stat-note'>{{item.pToDate}}</p>
+</div>
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pTwitterFollowers}}</p>
+    <p class='stat-figure'>18,364</p>
+    <p class='stat-note'>{{item.pToDate}}</p>
+</div>
+
+<div class='plain-stat-container'>
+    <p class='stat-label'>{{item.pSlackUsers}}</p>
+    <p class='stat-figure'>1,327</p>
+    <p class='stat-note'>{{item.pToDate}}</p>
+</div>

--- a/de/stats.html
+++ b/de/stats.html
@@ -24,29 +24,7 @@ language: Deutsch
     <p>{{ item.pBSQDistribution }}</p>
 </div>
 
-<div class='plain-stat-container'>
-    {{ item.pTotalTrades }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pDailyAverage }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSoftwareDownloads }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pGithubContributors }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pTwitterFollowers }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSlackUsers }}
-</div>
+{% include statistics_data.html %}
 
 <br>
 {{ item.pNetworkLoad }}

--- a/es/stats.html
+++ b/es/stats.html
@@ -24,29 +24,7 @@ language: Español
     <p>{{ item.pBSQDistribution }}</p>
 </div>
 
-<div class='plain-stat-container'>
-    {{ item.pTotalTrades }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pDailyAverage }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSoftwareDownloads }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pGithubContributors }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pTwitterFollowers }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSlackUsers }}
-</div>
+{% include statistics_data.html %}
 
 <br>
 {{ item.pNetworkLoad }}

--- a/fr/stats.html
+++ b/fr/stats.html
@@ -24,29 +24,7 @@ language: Français
     <p>{{ item.pBSQDistribution }}</p>
 </div>
 
-<div class='plain-stat-container'>
-    {{ item.pTotalTrades }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pDailyAverage }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSoftwareDownloads }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pGithubContributors }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pTwitterFollowers }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSlackUsers }}
-</div>
+{% include statistics_data.html %}
 
 <br>
 {{ item.pNetworkLoad }}

--- a/pt-PT/stats.html
+++ b/pt-PT/stats.html
@@ -24,29 +24,7 @@ language: Português (PT)
     <p>{{ item.pBSQDistribution }}</p>
 </div>
 
-<div class='plain-stat-container'>
-    {{ item.pTotalTrades }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pDailyAverage }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSoftwareDownloads }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pGithubContributors }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pTwitterFollowers }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSlackUsers }}
-</div>
+{% include statistics_data.html %}
 
 <br>
 {{ item.pNetworkLoad }}

--- a/stats.html
+++ b/stats.html
@@ -23,41 +23,8 @@ language: English
     <p>The mainnet <a href='https://docs.bisq.network/dao-user-reference.html#bsq-genesis-distribution' target='_blank'>BSQ genesis distribution</a> took place in April 2019.</p>
 </div>
 
-<div class='plain-stat-container'>
-    <p class='stat-label'>Total Trades</p>
-    <p class='stat-figure'>37,570</p>
-    <p class='stat-note'>Through August 2019</p>
-</div>
-
-<div class='plain-stat-container'>
-    <p class='stat-label'>Daily Average Trades</p>
-    <p class='stat-figure'>98</p>
-    <p class='stat-note'>For August 2019</p>
-</div>
-
-<div class='plain-stat-container'>
-    <p class='stat-label'>Software Downloads</p>
-    <p class='stat-figure'>10,381</p>
-    <p class='stat-note'>For v1.1.5 (approximate)</p>
-</div>
-
-<div class='plain-stat-container'>
-    <p class='stat-label'>GitHub Contributors</p>
-    <p class='stat-figure'>188</p>
-    <p class='stat-note'>As of August 2019</p>
-</div>
-
-<div class='plain-stat-container'>
-    <p class='stat-label'>Twitter Followers</p>
-    <p class='stat-figure'>18,364</p>
-    <p class='stat-note'>As of August 2019</p>
-</div>
-
-<div class='plain-stat-container'>
-    <p class='stat-label'>Slack Users</p>
-    <p class='stat-figure'>1,327</p>
-    <p class='stat-note'>As of August 2019</p>
-</div>
+{% assign item = site.data.strings_en.stats %}
+{% include statistics_data.html %}
 
 <br>
 <p class='monitor-note'>For P2P network load, Tor metrics, and other network data, please visit the <a href='https://monitor.bisq.network' target='_blank'>Bisq Network Monitor</a>.</p>

--- a/zh-CN/stats.html
+++ b/zh-CN/stats.html
@@ -24,29 +24,7 @@ language: 简体中文
     <p>{{ item.pBSQDistribution }}</p>
 </div>
 
-<div class='plain-stat-container'>
-    {{ item.pTotalTrades }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pDailyAverage }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSoftwareDownloads }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pGithubContributors }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pTwitterFollowers }}
-</div>
-
-<div class='plain-stat-container'>
-    {{ item.pSlackUsers }}
-</div>
+{% include statistics_data.html %}
 
 <br>
 {{ item.pNetworkLoad }}


### PR DESCRIPTION
The numeric values in the *Statistics* page needed to be manually added for all languages, this results in an updated page in English, but all other languages are obsolete. This PR removes the need to update each language every month (which is unsustainable), now it's enough to only change the number in the english yml file, the other languages will pull the data from there.
I also added generic time references (*last month* instead of *July*), to remove the need to translate every time the name of the past month (also unsustainable).

The only downside is that is assumed the data in the statistics page (the english version) will be updated each month, but this seems to be happening anyway.

Opening as WIP because **for this to be merged two strings need to be translated in all the available languages**: `Last month` and `As of last month`. Please provide the translation for: Spanish, German, Portuguese (pt-pt) and zh-cn.