### PR TITLE
Localize site name/description for metadata preview pane usage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,6 @@ exclude:
 paginate: 10
 paginate_path: "/blog/page/:num/"
 client_version: "1.1.5"
-description: "Bisq is an open-source desktop application that allows you to buy and sell bitcoins in exchange for national currencies, or alternative crypto currencies."
 sass:
   style: compressed
 webrick:

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -2,27 +2,41 @@
   tag: "en"
   enabled: No
   accept_languages: ["en", "en-us", "en-au", "en-nz", "en-za", "en-bz", "en-tt"]
+  site_name: "Bisq - The decentralized Bitcoin exchange"
+  site_desc: "Bisq is an open-source desktop application that allows you to buy and sell bitcoins in exchange for national currencies, or alternative cryptocurrencies."
 - name: "Deutsch"
   tag: "de"
   enabled: Yes
   accept_languages: ["de"]
+  site_name: "Bisq - The decentralized Bitcoin exchange"
+  site_desc: "Bisq is an open-source desktop application that allows you to buy and sell bitcoins in exchange for national currencies, or alternative cryptocurrencies."
 - name: "Español"
   tag: "es"
   enabled: Yes
   accept_languages: ["es", "es-mx", "es-gt", "es-cr", "es-pa", "es-do", "es-ve", "es-co", "es-pe", "es-ar", "es-ec", "es-cl", "es-uy", "es-py", "es-bo", "es-sv", "es-hn", "es-ni", "es-pr"]
+  site_name: "Bisq - The decentralized Bitcoin exchange"
+  site_desc: "Bisq is an open-source desktop application that allows you to buy and sell bitcoins in exchange for national currencies, or alternative cryptocurrencies."
 - name: "Français"
   tag: "fr"
   enabled: Yes
   accept_languages: ["fr", "fr-FR"]
+  site_name: "Bisq - La plateforme d'échange de Bitcoin décentralis"
+  site_desc: "Bisq est une application desktop open-source qui vous permet d'acheter et de vendre des bitcoins contre des devises nationales ou des altcoins."
 - name: "日本語"
   tag: "ja"
   enabled: No
   accept_languages: ["ja", "ja-jp"]
+  site_name: "Bisq - 取引所、非中央集権化された"
+  site_desc: "Bisqは、各国通貨と引き換えに暗号通貨と売買できるオープンソースのピアツーピアアプリケーションです。登録は不要です。"
 - name: "Português"
   tag: "pt-PT"
   enabled: Yes
   accept_languages: ["pt", "pt-PT"]
+  site_name: "Bisq - A exchange de Bitcoin descentralizada"
+  site_desc: "Bisq é uma aplicação de desktop open-source que lhe permite comprar e vender bitcoins em troca de moedas nacionais ou altcoin."
 - name: "简体中文"
   tag: "zh-CN"
   enabled: Yes
   accept_languages: ["zh", "zh-CN"]
+  site_name: "Bisq - 去中心化的比特币交易"
+  site_desc: "Bisq 是一个开源的电脑程序，使你能够使用当地货币或加密货币来买卖比特币。"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,11 @@
 <!doctype html>
 <html lang="{{ page.lang }}">
+{% for language in site.data.languages %}
+  {% if language.tag == page.lang %}
+    {% assign langdata = language %}
+	{% break %}
+  {% endif %}
+{% endfor %}
 
     <head>
 
@@ -8,19 +14,19 @@
 
         <meta name="author" content="Bisq">
 
-        <meta name="description" content="{{ site.description }}">
+        <meta name="description" content="{{ langdata.site_desc }}">
         <meta name="image" content="/images/bisq-og.jpg">
         <meta itemprop="name" content="Bisq">
-        <meta itemprop="description" content="{{ site.description }}">
+        <meta itemprop="description" content="{{ langdata.site_desc }}">
         <meta itemprop="image" content="/images/bisq-og.jpg">
         <meta name="og:title" content="{{ page.title }}">
-        <meta name="og:description" content="{{ site.description }}">
+        <meta name="og:description" content="{{ langdata.site_desc }}">
         <meta name="og:image" content="/images/bisq-og.jpg">
-        <meta name="og:site_name" content="Bisq - The decentralized Bitcoin exchange">
+        <meta name="og:site_name" content="{{ langdata.site_name }}">
         <meta name="og:type" content="website">
         <meta property="twitter:title" content="{{ page.title }}">
         <meta property="twitter:card" content="summary_large_image">
-        <meta property="twitter:site" content="Bisq - The decentralized Bitcoin exchange">
+        <meta property="twitter:site" content="{{ langdata.enabled }}">
         <meta name="twitter:creator" content="@bisq_network">
         <link rel="canonical" href="{{ page.url }}">
         {% if page.lang == "ja" %}


### PR DESCRIPTION
Allows you to localize the preview text on Slack, Twitter, etc. like this:

<img width="805" alt="Screen Shot 2019-09-06 at 10 02 08" src="https://user-images.githubusercontent.com/232186/64393654-6b428b00-d08d-11e9-9e21-89f0ccc0f9f4.png">