### PR TITLE
Refactor nav, content, footer conditions

### DIFF
--- a/404.md
+++ b/404.md
@@ -2,7 +2,7 @@
 layout: page
 permalink: /404.html
 title: Not Found
-ref: "404"
+en-only: true
 ---
 
 # 404

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,39 +67,31 @@
 
     <body class="home page-template-default page page-id-6 custom-background">
 
-<!--Select includes/main_nav according to page lang or absence of lang-->
-          {% if page.lang == "en" or page.ref == "blog" or page.ref == "404" %}
+        <!--Select includes/main_nav according to page lang or absence of lang-->
+        {% if page.lang == "en" or page.en-only %}
             {% include main_nav.html %}
-          {% else %}
+        {% else %}
             {% include main_nav_tr.html %}
-          {% endif %}
+        {% endif %}
 
-
-            {% if page.url == '/' %}
-
-                <div class="outter">
-                    {% include homepage_content.html %}
-                </div>
-
+        <div class="outter">
+        {% if page.ref == "index" %}
+            {% if page.lang == "en" %}
+                {% include homepage_content.html %}
             {% else %}
-
-                <div class="outter">
-<!-- Select includes/homepage_content according to page lang -->
-                  {% if page.ref == "index" %}
-                    {% include homepage_content_tr.html %}
-                  {% else %}
-                    {{ content }}
-                  {% endif %}
-                </div>
-
+                {% include homepage_content_tr.html %}
             {% endif %}
+        {% else %}
+            {{ content }}
+        {% endif %}
+        </div>
 
-<!-- Select includes/footer according to page lang -->
-              {% if page.lang == "en" or page.ref == "blog" %}
-                {% include footer.html %}
-              {% else %}
-                {% include footer_tr.html %}
-              {% endif %}
+        <!-- Select includes/footer according to page lang -->
+        {% if page.lang == "en" or page.en-only %}
+            {% include footer.html %}
+        {% else %}
+            {% include footer_tr.html %}
+        {% endif %}
 
 
         <!-- Matomo -->

--- a/_posts/2014-08-21-bitsquare-arbitration-system.md
+++ b/_posts/2014-08-21-bitsquare-arbitration-system.md
@@ -2,7 +2,7 @@
 layout: post
 title: The Bitsquare arbitration system
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 A video going into the details of the Arbitration system for Bitsquare:
 

--- a/_posts/2014-08-21-bitsquare-protection-mechanisms.md
+++ b/_posts/2014-08-21-bitsquare-protection-mechanisms.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bitsquare protection mechanisms
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 A video going into the details of the Protection Mechanisms system for Bitsquare:
 

--- a/_posts/2014-10-26-bitsquare-website-updated.md
+++ b/_posts/2014-10-26-bitsquare-website-updated.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bitsquare Website Updated
 author: Lloyd Johnson
-ref: blog
+en-only: true
 ---
 As the Bitsquare Application comes closer to a public Alpha we have been working hard towards updating the Bitsquare website too. The new website went live as of October 26, 2014.
 

--- a/_posts/2014-12-02-concept-overview.md
+++ b/_posts/2014-12-02-concept-overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: Concept overview
 author: Lloyd Johnson
-ref: blog
+en-only: true
 ---
 This video gives a basic overview about the concept behind Bitsquare:
 

--- a/_posts/2014-12-04-software-demo.md
+++ b/_posts/2014-12-04-software-demo.md
@@ -2,7 +2,7 @@
 layout: post
 title: Software demo
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 This video gives an overview about the application and guided through the trade process:
 

--- a/_posts/2014-12-16-bitsquare-now-in-alpha.md
+++ b/_posts/2014-12-16-bitsquare-now-in-alpha.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Bitsquare: Now in Alpha"
 author: Chris Beams
-ref: blog
+en-only: true
 ---
 After many months of research and development, we're excited to announce the release of [Bitsquare v0.1][1]. This marks the beginning of our alpha phase and the first major milestone on the road to a fully-functional Bitsquare v1.0.
 

--- a/_posts/2015-01-14-why-decentralisation-is-essential-for-bitcoins-utility-as-money.md
+++ b/_posts/2015-01-14-why-decentralisation-is-essential-for-bitcoins-utility-as-money.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Why decentralisation is essential for bitcoin's utility as money"
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 There was recently an important incident in the bitcoin space.
 

--- a/_posts/2015-01-22-reality-check.md
+++ b/_posts/2015-01-22-reality-check.md
@@ -2,7 +2,7 @@
 layout: post
 title: Reality check
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 We are glad to announce that we have started our new approach to iteratively fund the development of our project using [Lighthouse][1]. Please find all details about our campaign at the crowdfunding[2] section on our webpage.
 

--- a/_posts/2015-02-10-crowdfunding-campaign-conclusion.md
+++ b/_posts/2015-02-10-crowdfunding-campaign-conclusion.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crowdfunding campaign conclusion
 author: Richard Myers
-ref: blog
+en-only: true
 ---
 
 The Bitsquare crowdfunding[1] campaign has ended without reaching our funding goal.  We are disappointed, but also proud and encouraged by the amount of the support we did receive.   The enthusiasm we have seen from the community confirms we are on the right track and fuels our own passion to make Bitsquare a reality.

--- a/_posts/2015-03-12-update.md
+++ b/_posts/2015-03-12-update.md
@@ -2,7 +2,7 @@
 layout: post
 title: Update
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 I wanted to give a short update about the project state as things have changed a bit since the last Blog post.
 

--- a/_posts/2015-06-18-bitsquare-v0-4-payment-methods-and-arbitration-system.md
+++ b/_posts/2015-06-18-bitsquare-v0-4-payment-methods-and-arbitration-system.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bitsquare v0.4 (payment methods and arbitration system)"
 author: Manfred Karrer
 redirect_from: /blog/bitsquare-v0-4-payment-methods-and-arbitrtion-system
-ref: blog
+en-only: true
 ---
 Development update for verion 0.4 including a demonstration of the payment methods and the arbitration system:
 

--- a/_posts/2015-06-18-development-update.md
+++ b/_posts/2015-06-18-development-update.md
@@ -2,7 +2,7 @@
 layout: post
 title: Development update
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 It was a bit quiet here the last months, but there was going on a lot on the development front.
 

--- a/_posts/2015-07-25-killer-apps.md
+++ b/_posts/2015-07-25-killer-apps.md
@@ -2,7 +2,7 @@
 layout: post
 title: Killer apps
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 Regardless of what you think or whatever you got presented by the media regarding the [Greek crisis][1], I think many of you will agree, that our current political system is in need for a drastic improvement to say the least.
 Depending on the interpretation of the severity of the problem one might come to the conclusion that our political, economic and financial system is just **too broken to get fixed**.

--- a/_posts/2015-08-10-new-team-members.md
+++ b/_posts/2015-08-10-new-team-members.md
@@ -2,7 +2,7 @@
 layout: post
 title: New team members
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 Good news! Bitsquare is expanding: **Amanda Johnson** and **Mihail Mihaylov** were delighted to join our team.
 

--- a/_posts/2015-08-21-the-problem-with-crypto-governance-is-power.md
+++ b/_posts/2015-08-21-the-problem-with-crypto-governance-is-power.md
@@ -2,7 +2,7 @@
 layout: post
 title: The Problem with Crypto Governance is Power
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 The really interesting problem in the recent Bitcoin crisis is not the block size debate. Nearly everyone [agrees][1] that there is need for a solution, but the consensus ends there. The form that the solution should take – and even the urgency of the problem itself – are still both hotly debated.
 

--- a/_posts/2015-10-06-new-p2p-network.md
+++ b/_posts/2015-10-06-new-p2p-network.md
@@ -2,7 +2,7 @@
 layout: post
 title: New P2P network
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 Some of you might ask what causes the delay of the beta release which was planned for that summer.
 The reason for the delay is a change in a fundamental part of the application – **the P2P network**.

--- a/_posts/2016-04-27-beta-version-launched.md
+++ b/_posts/2016-04-27-beta-version-launched.md
@@ -2,7 +2,7 @@
 layout: post
 title: Beta version launched
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 A big day for Bitsquare – we have launched our [Beta version][1]!
 

--- a/_posts/2016-08-05-exploring-the-new-territory.md
+++ b/_posts/2016-08-05-exploring-the-new-territory.md
@@ -3,7 +3,7 @@ layout: post
 title: Exploring the new territory
 author: Manfred Karrer
 redirect_from: /blog/explorering-the-new-territory
-ref: blog
+en-only: true
 ---
 With the recent [Bitfinex heist][1] models for decentralized exchanges have received a bit more attention as usual.
 

--- a/_posts/2017-01-12-bitsquare-is-rebranding.md
+++ b/_posts/2017-01-12-bitsquare-is-rebranding.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bitsquare is rebranding
 author: Mihail Mihaylov
-ref: blog
+en-only: true
 ---
 Bitsquare has always been proud to say it is not a startup or a company, but a free open-source community project. It is being **developed without venture capital** or any other form of external funding, but with personal savings and donations from the community it serves.
 

--- a/_posts/2017-02-22-outcome-of-rebranding-bounty.md
+++ b/_posts/2017-02-22-outcome-of-rebranding-bounty.md
@@ -2,7 +2,7 @@
 layout: post
 title: Outcome of Rebranding Bounty
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 ### TL;DR
 <!--more-->

--- a/_posts/2017-03-06-bitsquare-becomes-bisq.md
+++ b/_posts/2017-03-06-bitsquare-becomes-bisq.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bitsquare becomes Bisq
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 We [announced](/blog/bitsquare-is-rebranding/) a while ago that we started rebranding as a result of trademark conflicts.
 

--- a/_posts/2017-03-29-privacy-in-bitsquare.md
+++ b/_posts/2017-03-29-privacy-in-bitsquare.md
@@ -2,7 +2,7 @@
 layout: post
 title: Privacy in Bisq
 author: Manfred Karrer
-ref: blog
+en-only: true
 ---
 To write a blog post about privacy in Bisq has been already a long time on my TODO list.
 

--- a/_posts/2017-07-20-the-bisq-dao-manifesto.md
+++ b/_posts/2017-07-20-the-bisq-dao-manifesto.md
@@ -4,7 +4,7 @@ title: The Bisq DAO manifesto
 author: Mats-Erik Pistol
 redirect_from:
   - /blog/the-bisq-dao--manifesto
-ref: blog
+en-only: true
 ---
 
 The Bisq DAO is a DAO that has been carefully designed to be stable against perturbations, such as majority attacks, scams and forks. The aim has been avoid any central points of failure or control and it is thus autonomous. It follows a general idea of DAOs, being based on network effects, modifiable computer programs and economic incentives. The Bisq DAO "controls" Bisq itself which is a p2p trading platform. The Bisq DAO has certain defining characteristics at its beginning, that we describe below:

--- a/_posts/2018-07-04-bisq-v0-7-1-released.md
+++ b/_posts/2018-07-04-bisq-v0-7-1-released.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bisq v0.7.1 released
 author: Chris Beams
-ref: blog
+en-only: true
 ---
 
 Bisq version 0.7.1 has been released. We recommend all users update immediately.

--- a/_posts/2018-12-13-bisq-dao-now-on-testnet.md
+++ b/_posts/2018-12-13-bisq-dao-now-on-testnet.md
@@ -2,7 +2,7 @@
 layout: post
 title: Bisq DAO now on testnet
 author: Steve Jain
-ref: blog
+en-only: true
 ---
 
 Bisq v0.9 is one of the biggest updates to Bisq ever: it brings the Bisq DAO to testnet, as well as a striking new visual design (among a host of other improvements and bug fixes).

--- a/_posts/2019-02-18-bisq-dao-for-bitcoin-maximalists.md
+++ b/_posts/2019-02-18-bisq-dao-for-bitcoin-maximalists.md
@@ -3,7 +3,7 @@ layout: post
 title: Bisq DAO for Bitcoin Maximalists
 author: Steve Jain
 excerpt: "Let's cut to the chase: the Bisq DAO is built on the Bitcoin network, and the BSQ token is just colored bitcoin.<br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-02-25-an-overview-of-the-bisq-network.md
+++ b/_posts/2019-02-25-an-overview-of-the-bisq-network.md
@@ -3,7 +3,7 @@ layout: post
 title: An Overview of the Bisq Network
 author: Aruna Surya
 excerpt: If you are into cryptocurrencies, you may be interested in Bisq, a decentralized exchange that enables you to trade bitcoin for fiat currencies and other cryptocurrencies. Unlike centralized exchanges, you preserve your privacy when trading on Bisq since there is no need for registration or approval from any central authorities. In this post, I will give you an overview of the Bisq software and the Bisq network.<br><br>
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-03-06-how-to-earn-bsq.md
+++ b/_posts/2019-03-06-how-to-earn-bsq.md
@@ -3,7 +3,7 @@ layout: post
 title: How to Earn BSQ by Contributing to Bisq
 author: John Forsyth
 excerpt: Bisq is an open-source software project, but it has a built-in revenue model to compensate its contributors—and anyone is welcome to contribute!<br><br>
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-03-13-dao-benefits-funding.md
+++ b/_posts/2019-03-13-dao-benefits-funding.md
@@ -3,7 +3,7 @@ layout: post
 title: "Benefits of the Bisq DAO, Part I: Funding FLOSS & Avoiding Surveillance Capitalism"
 author: Steve Jain
 excerpt: "The Bisq DAO enables value transfer and decision-making for the Bisq network. But it has several additional benefits too, which we'll focus on in this series.<br><br>In this post, Part I of this series, we'll discuss how Bisq's revenue model offers a new approach to funding open-source software development that, by design, avoids incentives to exploit user privacy altogether.<br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-03-22-how-to-set-up-bitcoin-regtest.md
+++ b/_posts/2019-03-22-how-to-set-up-bitcoin-regtest.md
@@ -3,7 +3,7 @@ layout: post
 title: "How to Set Up a Bitcoin Regtest Environment"
 author: Tomáš Kanócz
 excerpt: "In this post, Tomáš shows you how to set up your very own Bitcoin regtest environment with bitcoin-qt and make your own blocks! <br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-03-29-max-hillebrand-interview-privacy.md
+++ b/_posts/2019-03-29-max-hillebrand-interview-privacy.md
@@ -3,7 +3,7 @@ layout: post
 title: "Privacy Best Practices & Bisq: An Interview with Max Hillebrand"
 author: Ricardo Martinez
 excerpt: "Ricardo Martinez interviews Max Hillebrand of the World Crypto Network. They discuss privacy in general, privacy with respect to bitcoin, privacy with respect to Bisq, and more. <br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-04-08-why-aruna-surya.md
+++ b/_posts/2019-04-08-why-aruna-surya.md
@@ -3,7 +3,7 @@ layout: post
 title: "Why I Am a Bisq Contributor: Aruna Surya"
 author: Aruna Surya
 excerpt: "Aruna Surya discusses her experience with being a Bisq contributor—why she started contributing, why she continues contributing, and how there's still a lot to like for a non-technical person with diverging interests. <br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-04-17-dao-launch-third-anniversary.md
+++ b/_posts/2019-04-17-dao-launch-third-anniversary.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bisq DAO Launches with Bisq v1.0"
 author: Steve Jain
 excerpt: "After years in the making, the Bisq DAO has launched on mainnet with the v1.0 release of the Bisq software, just days before Bisq celebrates 3 years in production. <br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-04-30-ricardo-janine-rogue-bitcoin-interview.md
+++ b/_posts/2019-04-30-ricardo-janine-rogue-bitcoin-interview.md
@@ -3,7 +3,7 @@ layout: post
 title: "Why Some Bitcoin Companies Go Rogue: An Interview with Janine from Block Digest"
 author: Ricardo Martinez
 excerpt: "Ricardo Martinez interviews Janine of Block Digest. They discuss a peculiar phenomenon—the tendency for people and companies made successful by Bitcoin to turn against Bitcoin—and why it happens.<br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-05-16-let-the-dao-work.md
+++ b/_posts/2019-05-16-let-the-dao-work.md
@@ -3,7 +3,7 @@ layout: post
 title: "Time for the DAO to take over"
 author: Manfred Karrer
 excerpt: "With the DAO in place Bisq has to evolve its organisational structure without its founders. The departure of the founders was planned from the very beginning. Now it is time to fulfill that plan.<br><br>"
-ref: blog
+en-only: true
 ---
 
 Dear Bisq community,

--- a/_posts/2019-06-04-bitcoin-and-the-store-of-value-narrative.md
+++ b/_posts/2019-06-04-bitcoin-and-the-store-of-value-narrative.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bitcoin and the Store of Value Narrative"
 author: Manuel Polavieja
 excerpt: "Manuel posits that Bitcoin's value cannot be explained with a store-of-value approach. <br><br>"
-ref: blog
+en-only: true
 ---
 
 <hr>

--- a/_posts/2019-08-22-bisq-dao-first-four-cycles.md
+++ b/_posts/2019-08-22-bisq-dao-first-four-cycles.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bisq DAO: The First 4 Cycles"
 author: Steve Jain
 excerpt: "The Bisq DAO launched 4 months ago, after more than 4 years of development. It has now completed 4 voting cycles. In this post, we provide an update on how it's worked out so far. <br><br>"
-ref: blog
+en-only: true
 ---
 
 <div class='responsive-youtube-container'>

--- a/_posts/2019-09-18-cycle-5-results.md
+++ b/_posts/2019-09-18-cycle-5-results.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bisq DAO Cycle 5: Results"
 author: Steve Jain
 excerpt: "Cycle 5 of the Bisq DAO ended at block 595 146 on September 16 2019. This post covers its results, as well as an important lesson learned. <br><br>"
-ref: blog
+en-only: true
 ---
 
 Cycle 5 of the Bisq DAO went smoothly and resulted in some important decisions. There was also one incident which taught us an important lesson.

--- a/_posts/2019-10-29-bisq-v1-2-released.md
+++ b/_posts/2019-10-29-bisq-v1-2-released.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bisq v1.2 Launches with New Trade Protocol and Account Signing"
 author: Steve Jain
 excerpt: "New trade protocol moves to 2-of-2 multisig escrows for deposit funds, overhauls dispute resolution to be more private and scalable, and implements account signing to remove 0.01 BTC trade limits. <br><br>"
-ref: blog
+en-only: true
 ---
 
 The latest Bisq release is a big one with two significant updates: a new trade protocol and account signing.

--- a/_posts/2019-11-01-cycle-6-results.md
+++ b/_posts/2019-11-01-cycle-6-results.md
@@ -3,7 +3,7 @@ layout: post
 title: "Bisq DAO Cycle 6: Results"
 author: Steve Jain
 excerpt: "Cycle 6 of the Bisq DAO ended at block 599 826 on October 17 2019. This post covers its results. <br><br>"
-ref: blog
+en-only: true
 ---
 
 This post summarizes the results of Cycle 6 of the Bisq DAO.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Blog &lsaquo; Bisq - The decentralized Bitcoin exchange
-ref: blog
+en-only: true
 ---
 <a href="/blog/feed.atom" class="rss-link blog-index"><img src="/images/logo-rss.svg"></a>
 <h1 id="blog-index-header" class="mb-5">Bisq Blog</h1>

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,6 +2,7 @@
 layout: page
 title: Roadmap &lsaquo; Bisq - The decentralized Bitcoin exchange
 banner: /images/roadmap1.png
+en-only: true
 ---
 # Roadmap
 
@@ -52,7 +53,7 @@ This version improves the handling of failed trades and offers, loads the trade 
 - [Change type of ignoreLocalBtcNode to boolean](https://github.com/bisq-network/bisq/pull/3434)
 
 ###### Assets
-Added one new asset: LBRY Credits (LBC) 
+Added one new asset: LBRY Credits (LBC)
 
 ##### Version 1.2.2
 {: .mt-5 .mb-2}
@@ -95,7 +96,7 @@ Updating to v1.2 with unfinished trades and disputes will require an arbitrator 
 - [Translate name of Japan Bank Transfer for non-Japanese users](https://github.com/bisq-network/bisq/pull/3344)
 
 ###### Trading
-- New trade protocol: [1](https://github.com/bisq-network/bisq/pull/3333), [2](https://github.com/bisq-network/bisq/pull/3340), [2](https://github.com/bisq-network/bisq/pull/3410), [3](https://github.com/bisq-network/bisq/pull/3414), [4](https://github.com/bisq-network/bisq/pull/3420), [5](https://github.com/bisq-network/bisq/pull/3439), [6](https://github.com/bisq-network/bisq/pull/3453), [7](https://github.com/bisq-network/bisq/pull/3464), [8](https://github.com/bisq-network/bisq/pull/3471), [9](https://github.com/bisq-network/bisq/pull/3474), [10](https://github.com/bisq-network/bisq/pull/3475), 
+- New trade protocol: [1](https://github.com/bisq-network/bisq/pull/3333), [2](https://github.com/bisq-network/bisq/pull/3340), [2](https://github.com/bisq-network/bisq/pull/3410), [3](https://github.com/bisq-network/bisq/pull/3414), [4](https://github.com/bisq-network/bisq/pull/3420), [5](https://github.com/bisq-network/bisq/pull/3439), [6](https://github.com/bisq-network/bisq/pull/3453), [7](https://github.com/bisq-network/bisq/pull/3464), [8](https://github.com/bisq-network/bisq/pull/3471), [9](https://github.com/bisq-network/bisq/pull/3474), [10](https://github.com/bisq-network/bisq/pull/3475),
 - Account signing: [1](https://github.com/bisq-network/bisq/pull/3334), [2](https://github.com/bisq-network/bisq/pull/3342), [3](https://github.com/bisq-network/bisq/pull/3365), [4](https://github.com/bisq-network/bisq/pull/3370), [5](https://github.com/bisq-network/bisq/pull/3374), [6](https://github.com/bisq-network/bisq/pull/3388), [7](https://github.com/bisq-network/bisq/pull/3390), [8](https://github.com/bisq-network/bisq/pull/3392), [9](https://github.com/bisq-network/bisq/pull/3403), [10](https://github.com/bisq-network/bisq/pull/3404), [11](https://github.com/bisq-network/bisq/pull/3406), [12](https://github.com/bisq-network/bisq/pull/3409), [13](https://github.com/bisq-network/bisq/pull/3415), [14](https://github.com/bisq-network/bisq/pull/3421), [15](https://github.com/bisq-network/bisq/pull/3435), [16](https://github.com/bisq-network/bisq/pull/3436), [16](https://github.com/bisq-network/bisq/pull/3445), [17](https://github.com/bisq-network/bisq/pull/3448), [18](https://github.com/bisq-network/bisq/pull/3450), [19](https://github.com/bisq-network/bisq/pull/3465), [20](https://github.com/bisq-network/bisq/pull/3467), [21](https://github.com/bisq-network/bisq/pull/3481), [22](https://github.com/bisq-network/bisq/pull/3490), [23](https://github.com/bisq-network/bisq/pull/3495), [24](https://github.com/bisq-network/bisq/pull/3496), [25](https://github.com/bisq-network/bisq/pull/3497), [26](https://github.com/bisq-network/bisq/pull/3499)
 - [Add mediator prefix to trade statistics](https://github.com/bisq-network/bisq/pull/3351)
 - [Add combo block explorer for Blockstream.info + Mempool.space](https://github.com/bisq-network/bisq/pull/3377)
@@ -128,7 +129,7 @@ Released [September 16th 2019](https://github.com/bisq-network/bisq/releases/tag
 This version includes important improvements which require that all traders update for compatibility reasons.
 Trader chat enables users to have direct encrypted communication during the trade to resolve minor problems.
 Mediation is an additional dispute resolution layer before a trade goes to arbitration. Mediators do not have a key in the multisig escrow, so they can only evaluate a situation and make a suggestion. If this suggestion is accepted by both traders, the trade can be completed without involving an arbitrator. Otherwise, the trade goes to arbitration. See more information [here](https://docs.bisq.network/trading-rules.html#mediation).
-For backward compatibility reasons, mediation will be activated in 2 steps. 
+For backward compatibility reasons, mediation will be activated in 2 steps.
 - **By September 19, all traders need to have updated to v1.1.6, or they will not be able to trade.**
 - **On September 26, mediation will become available.**
 
@@ -154,7 +155,7 @@ Additionally this version features a dark mode, adds Japan Bank transfer and we'
 - [Show median value in trade statistics candle popup](https://github.com/bisq-network/bisq/pull/2976)
 - [Confusing message after making a payment](https://github.com/bisq-network/bisq/pull/2976)
 - [Update trading amount on Error to prevent popup loop](https://github.com/bisq-network/bisq/pull/3076)
-- [Improve usage of available height for lists](https://github.com/bisq-network/bisq/pull/3077) 
+- [Improve usage of available height for lists](https://github.com/bisq-network/bisq/pull/3077)
 - [Fix bugs in searchable dropdown](https://github.com/bisq-network/bisq/pull/3124)
 - [Increase top navigation button text size for Japanese locale](https://github.com/bisq-network/bisq/pull/3133)
 
@@ -288,7 +289,7 @@ Released [May 2nd 2019](https://github.com/bisq-network/bisq/releases/tag/v1.1.0
 
 As there is hardly any scam risk for crypto-to-crypto trades, this release decreases the security deposit amount for these trades back to the pre-DAO state. Also with this release, the time to synchronize the Bisq DAO state should be reduced a lot, and there are many smaller bug fixes and improvements.
 
-Most importantly, this release also includes a temporary restriction that blocks accounts that were created recently to trade in certain markets where we had scammers. **Users running older clients (< 1.1.0) will be completely blocked from trading**, so it is critical that you update as soon as possible! The upcoming release 1.2.0 will include a more robust set of features that should make it nearly impossible to scam traders on Bisq anymore. 
+Most importantly, this release also includes a temporary restriction that blocks accounts that were created recently to trade in certain markets where we had scammers. **Users running older clients (< 1.1.0) will be completely blocked from trading**, so it is critical that you update as soon as possible! The upcoming release 1.2.0 will include a more robust set of features that should make it nearly impossible to scam traders on Bisq anymore.
 
 ###### DAO
 - [Request blocks in case we have not received it](https://github.com/bisq-network/bisq/pull/2730)


### PR DESCRIPTION
There was a `ref` variable being used before which had to be singled out manually per page for headers to show correctly, resulting in some pages being left out (i.e., roadmap). 

This PR changes that to a single `en-only` variable so pages cannot be left out as long as they specify it in their front matter.

FYI most of the changes in roadmap.md are trailing spaces which my editor made automatically per the [.editorconfig](https://github.com/bisq-network/bisq-website/blob/master/.editorconfig).