### PR TITLE
Fix slow loading of charts on markets page for popular trading pairs

### DIFF
--- a/js/markets.js
+++ b/js/markets.js
@@ -273,7 +273,7 @@ function buildData( jsonUrl ){
 
     } else {
 
-        jsonUrl = 'https://markets.bisq.network/api/hloc?market=' + pair + '&timestamp=no' + '&interval=minute' + '&timestamp_from=' + '&timestamp_to=';
+        jsonUrl = 'https://markets.bisq.network/api/hloc?market=' + pair + '&timestamp=no' + '&interval=day' + '&timestamp_from=' + '&timestamp_to=';
         getTrades( pair );
         getOffers( pair );
 


### PR DESCRIPTION
[Background]
The Bisq Website features a /markets page which fetches historical trade and live offer data from the Bisq Markets API, and plots the data on graphs and tables. This page is located at https://bisq.network/markets

[Issue]
A few markets on Bisq have become quite popular, such as USD, EUR, and XMR. For these busier markets, the full data is now quite heavy because the website requests data with `interval=minute` - the responses have reached several MB in size. The result is that these busy market pages are slow to load:
https://bisq.network/markets/?currency=btc_usd
https://bisq.network/markets/?currency=btc_eur
https://bisq.network/markets/?currency=xmr_btc

[Fix]
By changing the data from `interval=minute` to `interval=day` the response size returns to a more reasonable size (100KB ~ 300KB). The tradeoff is that some charts will have slightly lower resolution due to the smaller datapoints, but the charts will load instantly instead of the current several second load time.
https://deploy-preview-285--bisq-website.netlify.com/markets/?currency=btc_usd
https://deploy-preview-285--bisq-website.netlify.com/markets/?currency=btc_eur
https://deploy-preview-285--bisq-website.netlify.com/markets/?currency=xmr_btc