### PR TITLE
Add benefactors page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,6 +42,9 @@
             <li>
               <a href="https://markets.bisq.network/api/" target="_blank" rel="noopener">Market Data API</a>
             </li>
+            <li>
+              <a href="/benefactors">Benefactors</a>
+            </li>
             <!--
             lets activate it once we have a dynamic content
             <li>

--- a/_redirects
+++ b/_redirects
@@ -68,6 +68,11 @@ layout: null
     {% continue %}
   {% endif %}
 
+  # don't redirect /benefactors
+  {% if first_seven == "benefac" %}
+    {% continue %}
+  {% endif %}
+
   # don't redirect language-specific URIs
   {% assign is_lang = 0 %}
   {% for language in site.data.languages %}

--- a/benefactors.md
+++ b/benefactors.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Benefactors &lsaquo; Bisq - The decentralized Bitcoin exchange
+ref: blog
+---
+
+# Benefactors
+{: .mb-5}
+
+### The following entities help Bisq with gratis open-source licenses and other in-kind contributions.
+{: .mt-5 .col-sm-12 .col-md-10 .pl-0}
+
+<br>
+
+<p><a href="https://www.ej-technologies.com/products/jprofiler/overview.html" target="_blank">ej-technologies JProfiler Java profiler</a> open-source license</p>
+
+<p><a href="https://www.jetbrains.com/idea/" target="_blank">JetBrains IntelliJ IDE</a> open-source license</p>
+
+<br>
+
+<p>Thank you!</p>


### PR DESCRIPTION
In exchange for open-source licenses.

The `ref: blog` front matter variable in `benefactors.md` is a temporary workaround to get the appropriate headers and footers. It is rectified with #284.