### PR TITLE
Add Schema.org JSON-LD Microdata for SEO (Homepage)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,11 +71,7 @@
             "applicationCategory": "FinanceApplication",
             "name": "Bisq",
             "image": "https://bisq.network/images/bisq-logo.svg",
-            "availableOnDevice": [
-                "Desktop",
-                "Smartphone",
-                "Tablet"
-            ],
+            "availableOnDevice": "Desktop",
             "author": {
             "@type": "Organization",
             "url": "https://bisq.network/dao/",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,9 +93,7 @@
             "operatingSystem": [
                 "Windows",
                 "Linux",
-                "OSX",
-                "iOs",
-                "Android"
+                "OSX"
             ],
             "releaseNotes": "https://github.com/bisq-network/bisq/releases",
             "screenshot": "https://bisq.network/images/bisq_screen0.svg",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,7 +69,7 @@
             "@context": "https://schema.org/",
             "@type": "SoftwareApplication",
             "applicationCategory": "FinanceApplication",
-            "name": "Bisq",
+            "name": "Bisq Network",
             "image": "https://bisq.network/images/bisq-logo.svg",
             "availableOnDevice": "Desktop",
             "author": {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,7 +95,7 @@
                 "Linux",
                 "OSX"
             ],
-            "releaseNotes": "https://github.com/bisq-network/bisq/releases",
+            "releaseNotes": "https://github.com/bisq-network/bisq/releases/latest",
             "screenshot": "https://bisq.network/images/bisq_screen0.svg",
             "softwareVersion": "{{ site.client_version }}",
             "aggregateRating": {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -97,17 +97,13 @@
             "operatingSystem": [
                 "Windows",
                 "Linux",
-                "OSX"
-            ],
-            "downloadUrl": "https://bisq.network/downloads/",
-            "fileSize": "10MB",
-            "operatingSystem": [
+                "OSX",
                 "iOs",
                 "Android"
             ],
             "releaseNotes": "https://github.com/bisq-network/bisq/releases",
             "screenshot": "https://bisq.network/images/bisq_screen0.svg",
-            "softwareVersion": "1.0.3.133",
+            "softwareVersion": "{{ site.client_version }}",
             "aggregateRating": {
             "@type": "AggregateRating",
             "ratingValue": "5",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,6 +111,7 @@
           }
         }
         </script>
+{% endunless %}
 
     </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,6 +63,7 @@
         <script defer src="/js/bootstrap.min.js"></script>
         <script defer src="/js/scripts.js"></script>
 
+{% unless page.layout == "post" %}
         <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
         <script type='application/ld+json'>
         {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,7 +73,7 @@
             "image": "https://bisq.network/images/bisq-logo.svg",
             "availableOnDevice": "Desktop",
             "author": {
-            "@type": "Organization",
+            "@type": "Project",
             "url": "https://bisq.network/dao/",
             "name": "Bisq Decentralized Autonomous Organization",
             "sameAs": [

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,7 +101,7 @@
             "aggregateRating": {
             "@type": "AggregateRating",
             "ratingValue": "5",
-            "ratingCount": "20"
+            "ratingCount": "5"
           },
           "offers": {
             "@type": "Offer",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -75,7 +75,7 @@
             "author": {
             "@type": "Project",
             "url": "https://bisq.network/",
-            "name": "Bisq Decentralized Autonomous Organization",
+            "name": "Bisq",
             "sameAs": [
                 "https://github.com/bisq-network",
                 "https://twitter.com/bisq_network",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,7 +96,7 @@
                 "OSX"
             ],
             "releaseNotes": "https://github.com/bisq-network/bisq/releases/latest",
-            "screenshot": "https://bisq.network/images/bisq_screen0.svg",
+            "screenshot": "https://bisq.network/images/bisq_screen0.png",
             "softwareVersion": "{{ site.client_version }}",
             "aggregateRating": {
             "@type": "AggregateRating",

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,6 +63,64 @@
         <script defer src="/js/bootstrap.min.js"></script>
         <script defer src="/js/scripts.js"></script>
 
+        <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->
+        <script type='application/ld+json'>
+        {
+            "@context": "https://schema.org/",
+            "@type": "SoftwareApplication",
+            "applicationCategory": "FinanceApplication",
+            "name": "Bisq",
+            "image": "https://bisq.network/images/bisq-logo.svg",
+            "availableOnDevice": [
+                "Desktop",
+                "Smartphone",
+                "Tablet"
+            ],
+            "author": {
+            "@type": "Organization",
+            "url": "https://bisq.network/dao/",
+            "name": "Bisq Decentralized Autonomous Organization",
+            "sameAs": [
+                "https://github.com/bisq-network",
+                "https://twitter.com/bisq_network",
+                "https://www.youtube.com/c/bisq-network",
+                "https://bisq.network/slack-invite",
+                "https://bisq.community/",
+                "https://lists.bisq.network/listinfo/bisq-contrib",
+                "https://webchat.freenode.net/?channels=bisq",
+                "https://www.reddit.com/r/bisq",
+                "https://keybase.io/team/bisq"
+	          ]
+            },
+            "downloadUrl": "https://bisq.network/downloads/",
+            "fileSize": "180MB",
+            "operatingSystem": [
+                "Windows",
+                "Linux",
+                "OSX"
+            ],
+            "downloadUrl": "https://bisq.network/downloads/",
+            "fileSize": "10MB",
+            "operatingSystem": [
+                "iOs",
+                "Android"
+            ],
+            "releaseNotes": "https://github.com/bisq-network/bisq/releases",
+            "screenshot": "https://bisq.network/images/bisq_screen0.svg",
+            "softwareVersion": "1.0.3.133",
+            "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "5",
+            "ratingCount": "20"
+          },
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+	    "priceCurrency": "BTC"
+          }
+        }
+        </script>
+
     </head>
 
     <body class="home page-template-default page page-id-6 custom-background">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,7 +74,7 @@
             "availableOnDevice": "Desktop",
             "author": {
             "@type": "Project",
-            "url": "https://bisq.network/dao/",
+            "url": "https://bisq.network/",
             "name": "Bisq Decentralized Autonomous Organization",
             "sameAs": [
                 "https://github.com/bisq-network",


### PR DESCRIPTION
We should add schema.org microdata to Bisq website for a better Search Engine Optimization as specified on [https://schema.org/SoftwareApplication](https://schema.org/SoftwareApplication) and [https://developers.google.com/search/docs/data-types/software-app?hl=en](https://developers.google.com/search/docs/data-types/software-app?hl=en).

Example of a Rich Snippet inside Google's SERP (search engine result page):
![Google Rich Snippet](https://developers.google.com/search/docs/data-types/images/software-apps.png)

### What is Microdata?
Microdata (like RDFa and Microformats) is a form of semantic mark-up designed to describe elements on a web page e.g. review, person, event etc. This mark-up can be combined with typical HTML properties to dedlfine each item type through the use of associated attributes. For example, ‘Person’ has the properties name, url and title – attributes can be applied to HTML tags to describe each property.

### What is Schema.org?
Schema.org is a universally supported vocabulary extension by Google, Microsoft and Yahoo! for mark-up languages such as Microdata. It is designed to make the lives of webmasters easier, by offering one standardised mark-up understood by all the major search engines. Currently, Schema.org is compatible with Microdata, RDFa and JSON-LD.

### What is JSON-LD?
Based on the popular JSON format, the linked data format JSON-LD allows webmasters to define the context of the data contained through the use of types and properties. When combined with Schema.org, these properties follow a standardised mark-up supported by major search engines, and joins Microdata & RDFa as methods for integration. Unlike Microdata & RDFa, JSON-LD offers greater ease of implementation with all the necessary mark-up contained within inline <script> tags, instead of wrapping HTML properties. However, as elegant and lightweight that JSON-LD is, there are some potential road blocks. In some instances it’s just not practical to mark-up content, for example that on a larger scale, as the content would need to be effectively repeated within the script tags in order to validate. Also as the mark-up is invisible, the likelihood of marking up content that is not on the visible page increases, which is against search engine usage guidelines. It is for these reasons that Google in particular still favours Microdata & RDFa for marking up HTML content.

### Why use markups on Bisq website?
Marking up content on Bisq website can:
- Lead to the generation of rich snippets in search engine results like the one showed on top
- Enhance CTR (Click Through Rate) from the search result
- Provide greater information to search engines to improve their understanding of the content on Bisq website

Read more about the importance of Rich Snippets: [https://yoast.com/what-are-rich-snippets/](https://yoast.com/what-are-rich-snippets/)