### PR TITLE
Fix arch linux package link

### DIFF
--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -46,7 +46,7 @@
   <img src="/images/icon-arch-linux-g.svg" class="os-icon os-icon-g" />
   <img src="/images/icon-arch-linux-w.svg" class="os-icon os-icon-w" /> Download for Arch Linux
   <div class="float-right">
-    <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">Arch User Repo</a></div>
+    <a href="https://aur.archlinux.org/packages/bisq/">Arch User Repo</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">

--- a/_includes/os_selector_options_tr.html
+++ b/_includes/os_selector_options_tr.html
@@ -47,7 +47,7 @@
   <img src="/images/icon-arch-linux-g.svg" class="os-icon os-icon-g" />
   <img src="/images/icon-arch-linux-w.svg" class="os-icon os-icon-w" /> {{ item.liArch }}
   <div class="float-right">
-    <a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.liArchText }}</a></div>
+    <a href="https://aur.archlinux.org/packages/bisq/">{{ item.liArchText }}</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">

--- a/de/downloads.html
+++ b/de/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/downloads.html
+++ b/downloads.html
@@ -43,7 +43,7 @@ language: English
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/es/downloads.html
+++ b/es/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/fr/downloads.html
+++ b/fr/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/ja/downloads.html
+++ b/ja/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/pt-BR/downloads.html
+++ b/pt-BR/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/pt-PT/downloads.html
+++ b/pt-PT/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>

--- a/zh-CN/downloads.html
+++ b/zh-CN/downloads.html
@@ -44,7 +44,7 @@ outdated_translation: false
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bisq-git">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>


### PR DESCRIPTION
The current bisq.network page points to a bad repository which is not
uploaded anymore (bisq-git). This PR points to the right repo (bisq)


Changes made automatically executing

`grep -r --files-with-matches bisq-git | xargs sed -i "s/bisq-git/bisq/g"`