### PR TITLE
Fix es/dao/ button "Ver más"

### DIFF
--- a/_data/dao_content_tr.yml
+++ b/_data/dao_content_tr.yml
@@ -80,7 +80,7 @@ es:
   target: "_blank"
   rel: "noopener"
   img: /es/images/DAO/dao_why.svg
-  id: porqué
+  id: why
 
 
 
@@ -94,7 +94,7 @@ es:
   target: "_blank"
   rel: "noopener"
   img: /es/images/DAO/dao_what.svg
-  id: que
+  id: what
 
 
 
@@ -119,7 +119,7 @@ es:
   target: "_blank"
   rel: "noopener"
   img: /es/images/DAO/dao_benefits.svg
-  id: beneficios
+  id: benefits
 
 fr:
 - title: "La DAO de Bisq"


### PR DESCRIPTION
![2019-11-27_1604](https://user-images.githubusercontent.com/42625753/69762394-afdf3f00-112f-11ea-94f1-640f281bc144.png)


This button will not work because it is linked to an id called #why and the section you should call has the id #porqué. I think it is better to keep everything in English so that these problems do not occur.