### PR TITLE
Fix fr/dao/ button "En savoir plus"

### DIFF
--- a/_data/dao_content_tr.yml
+++ b/_data/dao_content_tr.yml
@@ -141,7 +141,7 @@ fr:
   target: "_blank"
   rel: "noopener"
   img: /fr/images/DAO/dao_why.svg
-  id: Pourquoi
+  id: why
 
 
 
@@ -155,7 +155,7 @@ fr:
   target: "_blank"
   rel: "noopener"
   img: /fr/images/DAO/dao_what.svg
-  id: quel
+  id: what
 
 
 
@@ -169,7 +169,7 @@ fr:
   target: "_blank"
   rel: "noopener"
   img: /fr/images/DAO/dao_how.svg
-  id: Comment
+  id: how
 
 
 
@@ -180,7 +180,7 @@ fr:
   target: "_blank"
   rel: "noopener"
   img: /fr/images/DAO/dao_benefits.svg
-  id: avantages
+  id: benefits
 
 
 ja:


### PR DESCRIPTION
![fr-dao](https://user-images.githubusercontent.com/42625753/69762703-aacebf80-1130-11ea-8b84-1d50faff8ebc.png)

This button will not work because it is linked to an id called #why and the section you should call has the id #Pourquoi. I think it is better to keep everything in English so that these problems do not occur.