### PR TITLE
Add Schema.org JSON-LD Microdata for SEO (Articles)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,3 +25,27 @@ layout: page
   <br>
   <a href="/blog">« Back to Blog</a>
 </div>
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "{{ page.title }}",
+        "description": "{{ page.excerpt }}",
+        "image": "https://bisq.network/images/bisq-fav.png",  
+        "author": {
+            "@type": "Person",
+            "name": "{{ page.author }}"
+        },  
+        "publisher": {
+            "@type": "Organization",
+            "name": "Bisq",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://bisq.network/images/bisq-fav.png"
+            }
+        },
+        "datePublished": "{{ page.date }}",
+        "dateModified": "{{ page.date }}",
+        "mainEntityOfPage": "{{ site.url }}{{ page.url }}"
+    }
+</script>

--- a/_posts/2014-08-21-bitsquare-arbitration-system.md
+++ b/_posts/2014-08-21-bitsquare-arbitration-system.md
@@ -8,3 +8,25 @@ A video going into the details of the Arbitration system for Bitsquare:
 
 <iframe src="//player.vimeo.com/video/110391149" width="640" height="360" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "The Bitsquare arbitration system",
+  "description": "A video going into the details of the Arbitration system for Bitsquare:",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-04-21"
+}
+</script>

--- a/_posts/2014-08-21-bitsquare-protection-mechanisms.md
+++ b/_posts/2014-08-21-bitsquare-protection-mechanisms.md
@@ -8,3 +8,25 @@ A video going into the details of the Protection Mechanisms system for Bitsquare
 
 <iframe src="//player.vimeo.com/video/110391150" width="640" height="360" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare protection mechanisms",
+  "description": "A video going into the details of the Protection Mechanisms system for Bitsquare",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-04-21"
+}
+</script>

--- a/_posts/2014-10-26-bitsquare-website-updated.md
+++ b/_posts/2014-10-26-bitsquare-website-updated.md
@@ -10,3 +10,25 @@ One of the areas where Bitsquare needs help is in attracting additional Java dev
 
 If you are interested in helping to build Bitsquare then please check out the [Community page](/community) and become involved! Even if you're not able to devote much time to Bitsquare, it would mean the world to us if you would share our updated website on Social Media and Email with your friends and family who might be interested.
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare Website Updated",
+  "description": "As the Bitsquare Application comes closer to a public Alpha we have been working hard towards updating the Bitsquare website too. The new website went live as of October 26, 2014.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Lloyd Johnson"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-10-26"
+}
+</script>

--- a/_posts/2014-12-02-concept-overview.md
+++ b/_posts/2014-12-02-concept-overview.md
@@ -8,3 +8,25 @@ This video gives a basic overview about the concept behind Bitsquare:
 
 <iframe src="//player.vimeo.com/video/113833533" width="640" height="360" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Concept overview",
+  "description": "This video gives a basic overview about the concept behind Bitsquare.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Lloyd Johnson"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-12-02"
+}
+</script>

--- a/_posts/2014-12-04-software-demo.md
+++ b/_posts/2014-12-04-software-demo.md
@@ -8,3 +8,25 @@ This video gives an overview about the application and guided through the trade 
 
 <iframe src="//player.vimeo.com/video/113557042" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Software demo",
+  "description": "This video gives an overview about the application and guided through the trade process.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-12-04"
+}
+</script>

--- a/_posts/2014-12-16-bitsquare-now-in-alpha.md
+++ b/_posts/2014-12-16-bitsquare-now-in-alpha.md
@@ -69,3 +69,26 @@ Bitsquare will exit _beta_ with the release of v1.0, which we're setting a high 
 [19]: /blog/feed.atom
 [20]: http://bitsquare.us9.list-manage.com/subscribe?u=fee3c64b1504e7835a98b0ed3&id=dc09b9ca64
 [21]: /community/#mailing-list
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare: Now in Alpha",
+  "description": "After many months of research and development, we’re excited to announce the release of Bitsquare v0.1. This marks the beginning of our alpha phase and the first major milestone on the road to a fully-functional Bitsquare v1.0.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Chris Beams"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2014-12-16"
+}
+</script>

--- a/_posts/2015-01-14-why-decentralisation-is-essential-for-bitcoins-utility-as-money.md
+++ b/_posts/2015-01-14-why-decentralisation-is-essential-for-bitcoins-utility-as-money.md
@@ -56,3 +56,26 @@ A fully P2P economy may not be realistic for various reasons, but it should be c
 [9]: https://en.wikipedia.org/wiki/Fungibility
 [10]: https://bitcointalk.org/index.php?topic=279249.0
 [11]: https://bitcoin.org/en/developer-guide#term-merge-avoidance
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Why decentralisation is essential for bitcoin's utility as money",
+  "description": "There was recently an important incident in the bitcoin space.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-01-14"
+}
+</script>

--- a/_posts/2015-01-22-reality-check.md
+++ b/_posts/2015-01-22-reality-check.md
@@ -108,3 +108,25 @@ _"To change something build a new model that makes the existing model obsolete"_
 [14]: https://en.wikipedia.org/wiki/Tragedy_of_the_commons
 [15]: http://www.coindesk.com/coinbases-75-million-series-c/
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Reality check",
+  "description": "We are glad to announce that we have started our new approach to iteratively fund the development of our project using Lighthouse. Please find all details about our campaign at the crowdfunding2 section on our webpage.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-01-22"
+}
+</script>

--- a/_posts/2015-02-10-crowdfunding-campaign-conclusion.md
+++ b/_posts/2015-02-10-crowdfunding-campaign-conclusion.md
@@ -37,3 +37,26 @@ Thank you from all of us on the Bitsquare team!
 [6]: /press/
 [7]: http://web.archive.org/web/20160624114133/http://www.vinumeris.com/lighthouse/faq#max-pledges
 [8]: http://web.archive.org/web/20160305103048/http://vinumeris.com/projects/welcome
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Crowdfunding campaign conclusion",
+  "description": "The Bitsquare crowdfunding1 campaign has ended without reaching our funding goal. We are disappointed, but also proud and encouraged by the amount of the support we did receive. The enthusiasm we have seen from the community confirms we are on the right track and fuels our own passion to make Bitsquare a reality.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Richard Myers"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-02-10"
+}
+</script>

--- a/_posts/2015-03-12-update.md
+++ b/_posts/2015-03-12-update.md
@@ -30,3 +30,25 @@ Stay tuned and I hope we are getting closer to a fully decentralized Fiat-Bitcoi
 [2]: https://github.com/vinumeris/updatefx
 [3]: http://www.csg.uzh.ch/theses.html?thesisid=188
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Update",
+  "description": "I wanted to give a short update about the project state as things have changed a bit since the last Blog post.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-03-12"
+}
+</script>

--- a/_posts/2015-06-18-bitsquare-v0-4-payment-methods-and-arbitration-system.md
+++ b/_posts/2015-06-18-bitsquare-v0-4-payment-methods-and-arbitration-system.md
@@ -9,3 +9,25 @@ Development update for verion 0.4 including a demonstration of the payment metho
 
 <iframe src="//player.vimeo.com/video/131086362" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare v0.4 (payment methods and arbitration system)",
+  "description": "Development update for verion 0.4 including a demonstration of the payment methods and the arbitration system:",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-06-18"
+}
+</script>

--- a/_posts/2015-06-18-development-update.md
+++ b/_posts/2015-06-18-development-update.md
@@ -17,3 +17,26 @@ I just published a [video][1] of the current application showing all those new f
 Stay tuned we are getting closer to the release!
 
 [1]: https://vimeo.com/131086362
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Development update",
+  "description": "It was a bit quiet here the last months, but there was going on a lot on the development front.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-06-18"
+}
+</script>

--- a/_posts/2015-07-25-killer-apps.md
+++ b/_posts/2015-07-25-killer-apps.md
@@ -95,3 +95,26 @@ Those are the **killer apps** I am interested in – they might help us **to not
 [22]: https://ourbasicincome.wordpress.com/2015/06/18/circles-universal-basic-income/
 [23]: http://www.lietaer.com/2015/02/bernard-lietaer-why-we-need-a-monetary-ecosystem-inria-2014/
 [24]: https://www.youtube.com/watch?v=8oeiOeDq_Nc
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Killer apps",
+  "description": "Regardless of what you think or whatever you got presented by the media regarding the Greek crisis, I think many of you will agree, that our current political system is in need for a drastic improvement to say the least. Depending on the interpretation of the severity of the problem one might come to the conclusion that our political, economic and financial system is just too broken to get fixed.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-07-25"
+}
+</script>

--- a/_posts/2015-08-10-new-team-members.md
+++ b/_posts/2015-08-10-new-team-members.md
@@ -26,4 +26,25 @@ We also want to add a bit of background information about our recently joined te
 [9]: http://www.csg.uzh.ch/staff/bocek.html
 [10]: http://tomp2p.net/
 
-
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "New team members",
+  "description": "Good news! Bitsquare is expanding: Amanda Johnson and Mihail Mihaylov were delighted to join our team.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-08-10"
+}
+</script>

--- a/_posts/2015-08-21-the-problem-with-crypto-governance-is-power.md
+++ b/_posts/2015-08-21-the-problem-with-crypto-governance-is-power.md
@@ -79,3 +79,26 @@ However you describe this form of problem solving, it's nothing new. Only the to
 [7]: https://github.com/TierNolan/bips/blob/bip4x/bip-atom.mediawiki
 [8]: http://www.coincer.org/2015/01/27/atomic-protocol-1/
 [9]: http://mercuryex.com/
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "The Problem with Crypto Governance is Power",
+  "description": "The really interesting problem in the recent Bitcoin crisis is not the block size debate. Nearly everyone agrees that there is need for a solution, but the consensus ends there. The form that the solution should take – and even the urgency of the problem itself – are still both hotly debated.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-08-21"
+}
+</script>

--- a/_posts/2015-10-06-new-p2p-network.md
+++ b/_posts/2015-10-06-new-p2p-network.md
@@ -56,3 +56,26 @@ I hope that we can release the Beta version in about 2-6 weeks.
 [10]: https://en.wikipedia.org/wiki/Kademlia
 [11]: https://bitmessage.org/
 [12]: /roadmap/
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "New P2P network",
+  "description": "Some of you might ask what causes the delay of the beta release which was planned for that summer. The reason for the delay is a change in a fundamental part of the application – the P2P network.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2015-10-06"
+}
+</script>

--- a/_posts/2016-04-27-beta-version-launched.md
+++ b/_posts/2016-04-27-beta-version-launched.md
@@ -28,3 +28,25 @@ UPDATE: here is the video from the launch event:
 [6]: http://www.meetup.com/bitcoin-barcelona/events/230228028/
 [7]: /press/#upcoming
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Beta version launched",
+  "description": "A big day for Bitsquare – we have launched our Beta version!",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2016-04-27"
+}
+</script>

--- a/_posts/2016-08-05-exploring-the-new-territory.md
+++ b/_posts/2016-08-05-exploring-the-new-territory.md
@@ -131,3 +131,26 @@ If we start to explore the new possibilities, potential and characteristics of d
 [12]: https://openbazaar.org/
 [13]: https://bitsquare.typeform.com/to/cWQWrK
 [14]: https://www.youtube.com/watch?v=kZvWt29OG0s
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Exploring the new territory",
+  "description": "With the recent Bitfinex heist models for decentralized exchanges have received a bit more attention as usual.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2016-08-05"
+}
+</script>

--- a/_posts/2017-01-12-bitsquare-is-rebranding.md
+++ b/_posts/2017-01-12-bitsquare-is-rebranding.md
@@ -18,3 +18,25 @@ The project is now seeking a new brand name that will firmly establish its prese
 
 Manfred, Bitsquare's founder and lead dev, is offering a **bounty of 0.5 bitcoin** for the person whose proposed name ends up being selected by the team. You can find the details of the bounty in our [forum post](https://forum.bitsquare.io/t/bitsquare-bounty-0-5-btc-for-new-brand-name/1133).
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare is rebranding",
+  "description": "Bitsquare has always been proud to say it is not a startup or a company, but a free open-source community project. It is being developed without venture capital or any other form of external funding, but with personal savings and donations from the community it serves.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Mihail Mihaylov"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2017-01-12"
+}
+</script>

--- a/_posts/2017-02-22-outcome-of-rebranding-bounty.md
+++ b/_posts/2017-02-22-outcome-of-rebranding-bounty.md
@@ -48,3 +48,26 @@ Thank you once again to those who participated in the bounty hunt! Keep an eye o
 [6]: https://forum.bitsquare.io/users/mirelo/activity
 [8]: https://forum.bitsquare.io/users/vieuxvicq/activity
 [9]: https://forum.bitsquare.io/users/silverback/activity
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Outcome of Rebranding Bounty",
+  "description": "The team reviewed all bounty submissions, but there was no single name that clearly stood out. The Bitsquare bounty of 0.5 bitcoin will be distributed to those with best contributions.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2017-02-22"
+}
+</script>

--- a/_posts/2017-03-06-bitsquare-becomes-bisq.md
+++ b/_posts/2017-03-06-bitsquare-becomes-bisq.md
@@ -56,3 +56,26 @@ We try to schedule the whole rebranding before that release. There might be some
 Please help us to spread the word to make it easier for people to know that **Bitsquare becomes Bisq**.
 
 Until the rebranding has officially started, we are still Bitsquare 🙂
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitsquare becomes Bisq",
+  "description": "We announced a while ago that we started rebranding as a result of trademark conflicts.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2017-03-06"
+}
+</script>

--- a/_posts/2017-03-29-privacy-in-bitsquare.md
+++ b/_posts/2017-03-29-privacy-in-bitsquare.md
@@ -211,3 +211,26 @@ As we cannot expect much support from that side, let's build our new model as we
 [^bloom-filtering-privacy]: [Bloom filtering, privacy – Adam Back](https://www.reddit.com/r/bitcoin_devlist/comments/3bsugu/bloom_filtering_privacy_adam_back_feb_20_2015/)
 
 [1]: https://github.com/bitsquare/bitsquare/wiki/Switching-to-a-new-data-directory
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Privacy in Bisq",
+  "description": "To write a blog post about privacy in Bisq has been already a long time on my TODO list.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-03-29"
+}
+</script>

--- a/_posts/2017-07-20-the-bisq-dao-manifesto.md
+++ b/_posts/2017-07-20-the-bisq-dao-manifesto.md
@@ -28,3 +28,26 @@ The Bisq DAO is a DAO that has been carefully designed to be stable against pert
 Since the Bisq DAO is open source, autonomous and censorship resistant we think that it is the start of a new ecosystem with something close to living entities in it. We expect many different DAOs controlling different platforms. These DAOs might start to compete for certain markets. The forking and modifications of old DAOs to make new DAOs can be seen as the production of offspring. The DAOs have different missions, for some it is to make as much money as possible for their owners. Other DAOs may very well be of a cooperative nature where people collaborate via the DAO according to some common interest or goal. The governance can be different for different DAOs and it is possible that they employ anonymous CEOs who do representative voting. Very advanced DAOs might include AI engines to increase their chances of survival in case they compete. It is certainly doable to include a neural net based trading bot into Bisq.
 
 We see DAOs as an inevitable development of p2p software due to the tremendous economic advantage they have over centralized and regulated corporations. The Bisq DAO will certainly have properties that we have not thought about and may even fail. If this is the case we are sure that improved versions will appear solving any failure mode. The Bisq DAO will evolve and it is possible that some of its defining characteristics change over time. DAOs cannot be shut down, unless one shuts down the internet, and have in this respect some similarities to Bittorrent, Bitcoin and other open source p2p systems. If the Bisq DAO works as intended it will show that it is possible to incentivise open source p2p-projects, which is not a small feat by itself.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "The Bisq DAO manifesto",
+  "description": "The Bisq DAO is a DAO that has been carefully designed to be stable against perturbations, such as majority attacks, scams and forks. The aim has been avoid any central points of failure or control and it is thus autonomous. It follows a general idea of DAOs, being based on network effects, modifiable computer programs and economic incentives. The Bisq DAO “controls” Bisq itself which is a p2p trading platform. The Bisq DAO has certain defining characteristics at its beginning, that we describe below.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Mats-Erik Pistol"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2017-07-20"
+}
+</script>

--- a/_posts/2018-07-04-bisq-v0-7-1-released.md
+++ b/_posts/2018-07-04-bisq-v0-7-1-released.md
@@ -10,3 +10,26 @@ Bisq version 0.7.1 has been released. We recommend all users update immediately.
  - See the complete [release notes](https://github.com/bisq-network/bisq/releases/tag/v0.7.1) at GitHub
  - Download and install v0.7.1 at <https://bisq.network/downloads>
  - Follow the [Getting Started with Bisq](https://docs.bisq.network/getting-started) guide
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq v0.7.1 released",
+  "description": "Bisq version 0.7.1 has been released. We recommend all users update immediately.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Chris Beams"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2018-07-04"
+}
+</script>

--- a/_posts/2018-12-13-bisq-dao-now-on-testnet.md
+++ b/_posts/2018-12-13-bisq-dao-now-on-testnet.md
@@ -18,3 +18,26 @@ See complete [release notes for 0.9.0](https://github.com/bisq-network/bisq/rele
 You can download the latest version of Bisq with the updates [here on the Bisq website](https://bisq.network/downloads).
 
 If it's your first time using Bisq, follow our [Getting Started with Bisq](https://docs.bisq.network/getting-started) guide to make your first trade.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO now on testnet",
+  "description": "Bisq v0.9 is one of the biggest updates to Bisq ever: it brings the Bisq DAO to testnet, as well as a striking new visual design (among a host of other improvements and bug fixes).",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2018-12-13"
+}
+</script>

--- a/_posts/2019-02-18-bisq-dao-for-bitcoin-maximalists.md
+++ b/_posts/2019-02-18-bisq-dao-for-bitcoin-maximalists.md
@@ -127,3 +127,26 @@ And here's the first of a series of short videos we made on the Bisq DAO:
 </div>
 
 It's fair to question whether Bisq needs to avoid organizing itself under a legal entity, but if you can accept that doing so could have benefits, then a DAO and token are the only reasonable ways to make it work.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO for Bitcoin Maximalists",
+  "description": "Let's cut to the chase: the Bisq DAO is built on the Bitcoin network, and the BSQ token is just colored bitcoin.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-02-18"
+}
+</script>

--- a/_posts/2019-02-25-an-overview-of-the-bisq-network.md
+++ b/_posts/2019-02-25-an-overview-of-the-bisq-network.md
@@ -35,4 +35,25 @@ In addition to Bisq nodes, the network includes several other nodes, each with a
 You can learn more about Bisq [here](https://docs.bisq.network/intro.html) and how to install the Bisq software [here](https://docs.bisq.network/getting-started.html).
 For more technical details of the Bisq P2P network, please visit [this blog post by Manfred Karrer](https://bisq.network/blog/new-p2p-network/).
 
-
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "An Overview of the Bisq Network",
+  "description": "If you are into cryptocurrencies, you may be interested in Bisq, a decentralized exchange that enables you to trade bitcoin for fiat currencies and other cryptocurrencies. Unlike centralized exchanges, you preserve your privacy when trading on Bisq since there is no need for registration or approval from any central authorities. In this post, I will give you an overview of the Bisq software and the Bisq network.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Aruna Surya"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-02-25"
+}
+</script>

--- a/_posts/2019-03-06-how-to-earn-bsq.md
+++ b/_posts/2019-03-06-how-to-earn-bsq.md
@@ -159,3 +159,26 @@ Everybody has something different to offer, so it’s just a matter of focusing 
 So what are you waiting for?
 
 Get to work and start earning!
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "How to Earn BSQ by Contributing to Bisq",
+  "description": "Bisq is an open-source software project, but it has a built-in revenue model to compensate its contributors—and anyone is welcome to contribute!",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "John Forsyth"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-03-06"
+}
+</script>

--- a/_posts/2019-03-13-dao-benefits-funding.md
+++ b/_posts/2019-03-13-dao-benefits-funding.md
@@ -190,3 +190,26 @@ In the next part in this series, we will discuss how the Bisq DAO's incentive st
 <sup>2</sup> The company is a hugely beneficial entity. As Ronald Coase articulated in his article _The Nature of the Firm_ in 1937, companies dramatically lower transaction and coordination costs in the pursuit of business. The advent of the modern limited-liability joint-stock company has been a drastically under-appreciated enabler of modern progress.
 <br><br>
 <sup>3</sup> Furthermore, it's worth noting that [the software](https://github.com/bisq-network/bisq) makes it technically impossible to collect very much data in the first place.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "The Bisq DAO enables value transfer and decision-making for the Bisq network. But it has several additional benefits too, which we'll focus on in this series.
+In this post, Part I of this series, we'll discuss how Bisq's revenue model offers a new approach to funding open-source software development that, by design, avoids incentives to exploit user privacy altogether.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-03-13"
+}
+</script>

--- a/_posts/2019-03-22-how-to-set-up-bitcoin-regtest.md
+++ b/_posts/2019-03-22-how-to-set-up-bitcoin-regtest.md
@@ -118,3 +118,26 @@ Take note of the numbers below the “Balances” label in Figure 11. We have 50
 Interested in how to spend the reward, what a coinbase transaction is, and how a Bitcoin transaction works?
 
 Join me next time, where we will continue working with the blockchain we just created.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "How to Set Up a Bitcoin Regtest Environment",
+  "description": "In this post, Tomáš shows you how to set up your very own Bitcoin regtest environment with bitcoin-qt and make your own blocks!",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Tomáš Kanócz"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-03-22"
+}
+</script>

--- a/_posts/2019-03-29-max-hillebrand-interview-privacy.md
+++ b/_posts/2019-03-29-max-hillebrand-interview-privacy.md
@@ -157,3 +157,25 @@ If you’d like to help out and contribute to the Bisq open-source project,you c
 You can see Max’s shows—[Bitcoin to the Max](https://www.youtube.com/playlist?list=PLPj3KCksGbSZtGhC7nIr_Mf1oCeP8U1tV), [Open Source Everything](https://www.youtube.com/watch?v=41y_eGsdy2U&list=PLPj3KCksGbSb1h33FZbsrtr1feIIwTBHt), and [Bitcoin Optech Newsletter](https://www.youtube.com/watch?v=NAXwLHgYHjo&list=PLPj3KCksGbSY9pV6EI5zkHcut5UTCs1cp)—on the [World Crypto Network](https://www.youtube.com/user/WorldCryptoNetwork/).
 
 Finally, you can check out my blog for more Bitcoin content like this, [right here](https://www.coincache.net). I hope this article was useful for you.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Ricardo Martinez interviews Max Hillebrand of the World Crypto Network. They discuss privacy in general, privacy with respect to bitcoin, privacy with respect to Bisq, and more.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Ricardo Martinez"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-03-29"
+}
+</script>

--- a/_posts/2019-04-08-why-aruna-surya.md
+++ b/_posts/2019-04-08-why-aruna-surya.md
@@ -37,3 +37,26 @@ Contributors who build and maintain Bisq perform a very essential function, and 
 Apart from autonomy, what I like most about working at Bisq is the interaction with the amazing contributors from all over the world. I have had great conversations with writers, developers and translators who were generous with their time and provided valuable advice. I now know that the strength of Bisq is in its contributors. They are here because they believe that Bisq is important, and their values are aligned.
 
 Being a Bisq contributor made me think more carefully about privacy and IT security, and be more open to new ways of collaboration. Although I still find transparency in communication quite challenging, I can see the value in it. I have done a wide range of tasks such as writing, editing, reporting bugs and coordinating projects, and now I have a much clearer idea of how I can contribute best. Working remotely without any organizational hierarchy is definitely a challenge, and some miscommunication is bound to happen. However, I am amazed by how quickly the contributors react and mobilize their forces to fix problems, so I am very optimistic about this new approach to working together.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Why I Am a Bisq Contributor: Aruna Surya",
+  "description": "Aruna Surya discusses her experience with being a Bisq contributor—why she started contributing, why she continues contributing, and how there's still a lot to like for a non-technical person with diverging interests.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Aruna Surya"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-04-08"
+}
+</script>

--- a/_posts/2019-04-17-dao-launch-third-anniversary.md
+++ b/_posts/2019-04-17-dao-launch-third-anniversary.md
@@ -47,3 +47,26 @@ So it's been a heck of a week.
 But while there's lots to celebrate from the past, we also realize this is also a celebration of a _beginning_ for the future. There's lots to do, and success is never guaranteed.
 
 We thank everyone for their support over the past several years, and look forward to an even brighter future.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO Launches with Bisq v1.0",
+  "description": "After years in the making, the Bisq DAO has launched on mainnet with the v1.0 release of the Bisq software, just days before Bisq celebrates 3 years in production.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-04-17"
+}
+</script>

--- a/_posts/2019-04-30-ricardo-janine-rogue-bitcoin-interview.md
+++ b/_posts/2019-04-30-ricardo-janine-rogue-bitcoin-interview.md
@@ -152,3 +152,25 @@ You can [follow Janine on Twitter here](https://twitter.com/J9Roem).
 You can [follow Shinobi on Twitter here](https://twitter.com/brian_trollz).
 
 You can [follow Rick on Twitter here](https://twitter.com/cryptorick).
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Ricardo Martinez interviews Janine of Block Digest. They discuss a peculiar phenomenon—the tendency for people and companies made successful by Bitcoin to turn against Bitcoin—and why it happens.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Ricardo Martinez"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-04-30"
+}
+</script>

--- a/_posts/2019-05-16-let-the-dao-work.md
+++ b/_posts/2019-05-16-let-the-dao-work.md
@@ -35,3 +35,26 @@ But there is more. Many interesting ideas and proposals are out and waiting for 
 So you can see a lot of challenging work is waiting for talented developers who want to become part of Bisq and help to build the infrastructure Bitcoin deserves: **a privacy protecting on-ramp which follows the principles of Bitcoin and not those of the banks.**
 
 If you are interested to work in a project that's permissionless and non-hierarchical by design, Bisq might be your [place](https://docs.bisq.network/contributor-checklist.html).
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Time for the DAO to take over",
+  "description": "With the DAO in place Bisq has to evolve its organisational structure without its founders. The departure of the founders was planned from the very beginning. Now it is time to fulfill that plan.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manfred Karrer"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-05-16"
+}
+</script>

--- a/_posts/2019-06-04-bitcoin-and-the-store-of-value-narrative.md
+++ b/_posts/2019-06-04-bitcoin-and-the-store-of-value-narrative.md
@@ -71,3 +71,26 @@ So, how is it that a completely new monetary good's price is discovered? That is
 **Conclusion**
 
 Bitcoin's origin of value can be fully explained on the grounds of the subjective theory of value and Menger's definition of money.  Because the need for exchange is a basic human need, any good that has the qualities to satisfy that need, (even if it only satisfies that one need), is useful and therefore subject to being demanded.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bitcoin and the Store of Value Narrative",
+  "description": "Manuel posits that Bitcoin's value cannot be explained with a store-of-value approach.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Manuel Polavieja"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-06-04"
+}
+</script>

--- a/_posts/2019-08-22-bisq-dao-first-four-cycles.md
+++ b/_posts/2019-08-22-bisq-dao-first-four-cycles.md
@@ -178,3 +178,26 @@ At roughly the same time as the DAO launch in April, it became clear that the ne
 Also needed quickly is the implementation of [a new trade protocol](https://github.com/bisq-network/proposals/issues/52) to remove arbitrators and embrace off-chain trading. Getting rid of arbitrators is a crucial step forward in hardening the network. This is a significant project that will require more developers to finish it in a reasonable timeframe.
 
 The successful launch of the Bisq DAO made [the ambitious vision](https://docs.bisq.network/dao/phase-zero.html) laid out in Phase Zero real. But big challenges remain, and the network must figure out how to conquer these challenges if it is to really succeed and realize its ultimate vision of becoming _the_ Bitcoin on/off-ramp.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO: The First 4 Cycles",
+  "description": "The Bisq DAO launched 4 months ago, after more than 4 years of development. It has now completed 4 voting cycles. In this post, we provide an update on how it's worked out so far.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-08-22"
+}
+</script>

--- a/_posts/2019-09-18-cycle-5-results.md
+++ b/_posts/2019-09-18-cycle-5-results.md
@@ -114,3 +114,27 @@ And here are voting results of the "lio" proposal. Some rejections, but most peo
 Open governance can only work if participants take the time and pay the attention needed to make responsible decisions.
 
 **Please make sure you do your due diligence before voting!**
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO Cycle 5: Results",
+  "description": "Cycle 5 of the Bisq DAO ended at block 595 146 on September 16 2019. This post covers its results, as well as an important lesson learned.
+",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-09-18"
+}
+</script>

--- a/_posts/2019-10-29-bisq-v1-2-released.md
+++ b/_posts/2019-10-29-bisq-v1-2-released.md
@@ -70,3 +70,26 @@ Please note exceptions:
 * account signing is not required for _any_ payment accounts used outside of major national currency markets on Bisq (USD, EUR, CAD, GBP, AUD, BRL)
 
 See more details on how this works in [documentation](https://docs.bisq.network/payment-methods#account-signing).
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq v1.2 Launches with New Trade Protocol and Account Signing",
+  "description": "New trade protocol moves to 2-of-2 multisig escrows for deposit funds, overhauls dispute resolution to be more private and scalable, and implements account signing to remove 0.01 BTC trade limits.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-10-29"
+}
+</script>

--- a/_posts/2019-11-01-cycle-6-results.md
+++ b/_posts/2019-11-01-cycle-6-results.md
@@ -41,3 +41,26 @@ _Rejected_
 This somewhat contentious proposal to more tightly integrate Monero with Bisq garnered only 5 votes from the 13 ballots cast in this cycle, and 98.85% of the voting weight of those 5 votes opposed the proposal (proposals need less than 49.99% of opposing voting weight to be approved).
 
 The proposal raised larger questions about conventions to integrate relatively large, experimental, and perhaps risky components into the code base. An [incubator space](https://github.com/bisq-network/proposals/issues/122){:target="_blank"} was proposed but is now being reconsidered. Several contributors have suggested opening a dialogue on the subject after the launch of v1.2.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO Cycle 6: Results",
+  "description": "Cycle 6 of the Bisq DAO ended at block 599 826 on October 17 2019. This post covers its results.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-11-01"
+}
+</script>

--- a/_posts/2019-11-22-cycle-7-results.md
+++ b/_posts/2019-11-22-cycle-7-results.md
@@ -58,3 +58,26 @@ While this is not what people wanted to hear, it's possible expectations for the
 And of course, liability on the network itself is reduced significantly without the third key.
 
 How will this new setup work? We shall see. Minimizing the need for dispute resolution (bug-fixing, user interface enhancements, etc) is now a high development priority for the near-future.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Bisq DAO Cycle 7: Results",
+  "description": "Cycle 7 of the Bisq DAO ended at block 604 506 on November 19 2019. This post covers its results.",
+  "image": "https://bisq.network/images/bisq-fav.png",  
+  "author": {
+    "@type": "Person",
+    "name": "Steve Jain"
+  },  
+  "publisher": {
+    "@type": "Organization",
+    "name": "Bisq Decentralized Autonomous Organization",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://bisq.network/images/bisq-fav.png"
+    }
+  },
+  "datePublished": "2019-11-22"
+}
+</script>


### PR DESCRIPTION
Following #290 and #291 

As specified on [https://developers.google.com/search/docs/data-types/article](https://developers.google.com/search/docs/data-types/article)

Final result:
![Two non-carousel results for non-AMP web pages.](https://developers.google.com/search/docs/data-types/images/articles01.png)

![Carousel results for non-AMP web pages.](https://developers.google.com/search/docs/data-types/images/articles02.png)

This will boost traffic and SEO for Bisq.network.

@m52go unfortunately, for `NewsArticle` we cannot use `Project` as `Publisher`. Google accepts `Organization` only. By the way, I specified `Bisq Decentralized Autonomous Organization` as `publisher.name`.

It does not mean in any way that Bisq is a "standard" company.
From now on it would be ideal to use this scheme for each article we publish and, if possible, add a unique image for each one.