### PR TITLE
Add Schema.org JSON-LD Microdata for SEO (Articles)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,3 +25,28 @@ layout: page
   <br>
   <a href="/blog">« Back to Blog</a>
 </div>
+
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "{{ page.title }}",
+        "description": "{{ page.excerpt }}",
+        "image": "https://bisq.network/images/bisq-fav.png",  
+        "author": {
+            "@type": "Person",
+            "name": "{{ page.author }}"
+        },  
+        "publisher": {
+            "@type": "Organization",
+            "name": "Bisq",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://bisq.network/images/bisq-fav.png"
+            }
+        },
+        "datePublished": "{{ page.date }}",
+        "dateModified": "{{ page.date }}",
+        "mainEntityOfPage": "{{ site.url }}{{ page.url }}"
+    }
+</script>


### PR DESCRIPTION
Following #290 and #291. Replace #300

As specified on [https://developers.google.com/search/docs/data-types/article](https://developers.google.com/search/docs/data-types/article)

Final result:
![Two non-carousel results for non-AMP web pages.](https://developers.google.com/search/docs/data-types/images/articles01.png)

![Carousel results for non-AMP web pages.](https://developers.google.com/search/docs/data-types/images/articles02.png)

This will boost traffic and SEO for Bisq.network.

@m52go unfortunately, for `NewsArticle` we cannot use `Project` as `Publisher`. Google accepts `Organization` only. By the way, I specified `Bisq Decentralized Autonomous Organization` as `publisher.name`.

It does not mean in any way that Bisq is a "standard" company.
From now on it would be ideal to use this scheme for each article we publish and, if possible, add a unique image for each one.