### PR TITLE
Fix Opengraph tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,11 +19,11 @@
         <meta itemprop="name" content="Bisq">
         <meta itemprop="description" content="{{ langdata.site_desc }}">
         <meta itemprop="image" content="/images/bisq-og.jpg">
-        <meta name="og:title" content="{{ page.title }}">
-        <meta name="og:description" content="{{ langdata.site_desc }}">
-        <meta name="og:image" content="/images/bisq-og.jpg">
-        <meta name="og:site_name" content="{{ langdata.site_name }}">
-        <meta name="og:type" content="website">
+        <meta property="og:title" content="{{ page.title }}">
+        <meta property="og:description" content="{{ langdata.site_desc }}">
+        <meta property="og:image" content="/images/bisq-og.jpg">
+        <meta property="og:site_name" content="{{ langdata.site_name }}">
+        <meta property="og:type" content="website">
         <meta property="twitter:title" content="{{ page.title }}">
         <meta property="twitter:card" content="summary_large_image">
         <meta property="twitter:site" content="{{ langdata.enabled }}">


### PR DESCRIPTION
The Open Graph protocol enables any web page to become a rich object in a social graph. For instance, this is used on Facebook to allow any web page to have the same functionality as any other object on Facebook.

This PR fixes `meta` tags, because they were wrong. 