### PR TITLE
Fix Opengraph and Twitter tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,9 +24,12 @@
         <meta property="og:image" content="/images/bisq-og.jpg">
         <meta property="og:site_name" content="{{ langdata.site_name }}">
         <meta property="og:type" content="website">
+        <meta property="og:url" content="https://bisq.network/">
         <meta property="twitter:title" content="{{ page.title }}">
         <meta property="twitter:card" content="summary_large_image">
-        <meta property="twitter:site" content="{{ langdata.enabled }}">
+        <meta property="twitter:site" content="https://bisq.network/">
+        <meta property="twitter:description" content="{{ langdata.site_desc }}">
+        <meta property="twitter:image" content="/images/bisq-og.jpg">
         <meta name="twitter:creator" content="@bisq_network">
         <link rel="canonical" href="{{ page.url }}">
         {% if page.lang == "ja" %}


### PR DESCRIPTION
Added `<meta property="og:url">`, `<meta property="twitter:description">` and `<meta property="twitter:image">` tags as they were missing.

Fixed `<meta property="twitter:site">` as it was broken

Marking up content on Bisq website can:

- Lead to the generation of rich snippets in search engine results like the one showed on top
- Enhance CTR (Click Through Rate) from the search result
- Provide greater information to search engines to improve their understanding of the content on Bisq website