### PR TITLE
Align `The Bisq DAO` feature on mobile

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1084,6 +1084,10 @@ faq page
     column-gap: 0;
   }
 
+  #dao-callout {
+    text-align: left;
+    margin: 2em auto 0 auto;
+  }
 
 }
 


### PR DESCRIPTION
On Bisq.network homepage, right after `No Identity Verification`, `Decentralized`, `Safe`, `Private`, `Open` and `Easy to Use` feaures, there is `The Bisq DAO` (div id -> `#dao-callout`) which, on smartphone, is not aligned with the rest of the Features.

This PR fixes view the view on smartphones.

Screenshots from iPhone X:
**Before**
![before](https://user-images.githubusercontent.com/46527252/71941294-78959080-31b9-11ea-8703-c514a7982148.png)


**After**
![after](https://user-images.githubusercontent.com/46527252/71941300-7b908100-31b9-11ea-9f44-a17e9a2e6b12.png)
