### PR TITLE
Add <a> title attribute to os selector

### DIFF
--- a/_includes/os_selector_options.html
+++ b/_includes/os_selector_options.html
@@ -2,7 +2,7 @@
   <img src="/images/icon-download-g.svg" class="os-icon os-icon-g" alt="Download Bisq" loading="lazy" />
   <img src="/images/icon-download-w.svg" class="os-icon os-icon-w" alt="Download Bisq" loading="lazy" />All Downloads
   <div class="float-right">
-    <a href="/downloads/">Go to Downloads Page</a>
+    <a href="/downloads/" title="Downloads">Go to Downloads Page</a>
   </div>
 </div>
 
@@ -10,7 +10,7 @@
   <img src="/images/icon-windows-g.svg" class="os-icon os-icon-g" alt="Download Bisq for Windows" loading="lazy" />
   <img src="/images/icon-windows-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Windows" loading="lazy" /> Download for Windows
   <div class="float-right">
-    <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+    <a class="dl-win64" title="Download Bisq for Windows" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
   </div>
 </div>
 
@@ -20,7 +20,7 @@
   <img src="/images/icon-apple-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Mac" loading="lazy" />
                                        Download for Mac
   <div class="float-right">
-    <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+    <a class="dl-mac" title="Download Bisq for Mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
   </div>
 </div>
 
@@ -30,7 +30,7 @@
   <img src="/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Ubuntu/Debian" loading="lazy" /> 
   Download for Debian/Ubuntu
   <div class="float-right">
-    <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
+    <a class="dl-deb64" title="Download Bisq for Ubuntu/Debian" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
   </div>
 </div>
 
@@ -40,7 +40,7 @@
   <img src="/images/icon-fedora-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Red Hat/Fedora" loading="lazy" /> 
   Download for Red Hat/Fedora
   <div class="float-right">
-    <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>
+    <a class="dl-rpm64" title="Download Bisq for Red Hat/Fedora" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>
   </div>
 </div>
 
@@ -50,7 +50,7 @@
   <img src="/images/icon-arch-linux-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Arch Linux" loading="lazy" /> 
   Download for Arch Linux
   <div class="float-right">
-    <a href="https://aur.archlinux.org/packages/bisq/">Arch User Repo</a></div>
+    <a href="https://aur.archlinux.org/packages/bisq/" title="Download Bisq for Arch Linux">Arch User Repo</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
@@ -58,8 +58,8 @@
   <img src="/images/icon-opensource-w.svg" class="os-icon os-icon-w" alt="Source Code" loading="lazy" /> 
   Source Code
   <div class="float-right">
-    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip">zip</a> |
-    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></div>
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip" title="Download Bisq Source Code">zip</a> |
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz" title="Download Bisq Source Code">tar.gz</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
@@ -67,7 +67,7 @@
   <img src="/images/icon-notes-w.svg" class="os-icon os-icon-w" alt="Release Notes" loading="lazy" /> 
   Release Notes
   <div class="float-right">
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}">v{{ site.client_version }}</a>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}" title="See Bisq Release Notes">v{{ site.client_version }}</a>
   </div>
 </div>
 
@@ -76,6 +76,6 @@
   <img src="/images/icon-verification-w.svg" class="os-icon os-icon-w" alt="Verification" loading="lazy" /> 
   Verification
   <div class="float-right">
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}">PGP signatures</a> |
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc">PGP Public Key</a></div>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}" title="Verify PGP Signatures">PGP signatures</a> |
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc" title="Verify PGP Signatures">PGP Public Key</a></div>
 </div>

--- a/_includes/os_selector_options_tr.html
+++ b/_includes/os_selector_options_tr.html
@@ -4,7 +4,7 @@
   <img src="/images/icon-download-w.svg" class="os-icon os-icon-w" alt="Download Bisq" loading="lazy">
   {{ item.liAllDownloads }}
   <div class="float-right">
-    <a href="/{{ page.lang }}/downloads/">{{ item.liAllDownloadsText }}</a>
+    <a href="/{{ page.lang }}/downloads/" title="">{{ item.liAllDownloadsText }}</a>
   </div>
 </div>
 
@@ -13,7 +13,7 @@
   <img src="/images/icon-windows-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Windows" loading="lazy" />
   {{ item.liWindows }}
   <div class="float-right">
-    <a class="dl-win64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
+    <a class="dl-win64" title="Download Bisq for Windows" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.exe">.exe</a>
   </div>
 </div>
 
@@ -23,7 +23,7 @@
   <img src="/images/icon-apple-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Mac" loading="lazy" />
   {{ item.liMac }}
   <div class="float-right">
-    <a class="dl-mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
+    <a class="dl-mac" title="Download Bisq for Mac" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-{{ site.client_version }}.dmg">.dmg</a>
   </div>
 </div>
 
@@ -33,7 +33,7 @@
   <img src="/images/icon-ubuntu-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Debian/Ubuntu" loading="lazy" />
   {{ item.liDebian }}
   <div class="float-right">
-    <a class="dl-deb64" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
+    <a class="dl-deb64" title="Download Bisq for Debian/Ubuntu" href="https://bisq.network/downloads/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.deb">.deb</a>
   </div>
 </div>
 
@@ -43,7 +43,7 @@
   <img src="/images/icon-fedora-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Red Hat/Fedora" loading="lazy" />
   {{ item.liRedHat }}
   <div class="float-right">
-    <a class="dl-rpm64" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>
+    <a class="dl-rpm64" title="Download Bisq for Red Hat/Fedora" href="https://github.com/bisq-network/bisq/releases/download/v{{ site.client_version }}/Bisq-64bit-{{ site.client_version }}.rpm">.rpm</a>
   </div>
 </div>
 
@@ -53,7 +53,7 @@
   <img src="/images/icon-arch-linux-w.svg" class="os-icon os-icon-w" alt="Download Bisq for Arch Linux" loading="lazy" />
   {{ item.liArch }}
   <div class="float-right">
-    <a href="https://aur.archlinux.org/packages/bisq/">{{ item.liArchText }}</a></div>
+    <a href="https://aur.archlinux.org/packages/bisq/" title="Download Bisq for Arch Linux">{{ item.liArchText }}</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
@@ -61,8 +61,8 @@
   <img src="/images/icon-opensource-w.svg" class="os-icon os-icon-w" alt="Source Code" loading="lazy" />
   {{ item.liSourceCode }}
   <div class="float-right">
-    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip">zip</a> |
-    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz">tar.gz</a></div>
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip" title="Download Bisq Source Code">zip</a> |
+    <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz" title="Download Bisq Source Code">tar.gz</a></div>
 </div>
 
 <div class="dropdown-item btn-icon">
@@ -70,7 +70,7 @@
   <img src="/images/icon-notes-w.svg" class="os-icon os-icon-w" alt="Release Notes" loading="lazy" />
   {{ item.liReleaseNotes }}
   <div class="float-right">
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}">v{{ site.client_version }}</a>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}" title="See Release Notes">v{{ site.client_version }}</a>
   </div>
 </div>
 
@@ -79,6 +79,6 @@
   <img src="/images/icon-verification-w.svg" class="os-icon os-icon-w" alt="Verification" loading="lazy" />
   {{ item.liVerification }}
   <div class="float-right">
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}">{{ item.liVerificationText1 }}</a> |
-    <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc">{{ item.liVerificationText2 }}</a></div>
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}" title="Verify PGP Signature">{{ item.liVerificationText1 }}</a> |
+    <a href="https://bisq.network/downloads/v{{ site.client_version }}/29CDFD3B.asc" title="Verify PGP Signature">{{ item.liVerificationText2 }}</a></div>
 </div>


### PR DESCRIPTION
Meta title tags are a major factor in helping search engines understand what pages are about. Title tags are used in three key places:
- search engine results pages (SERPs)
- web browsers
- social networks.