### PR TITLE
Implement pedro's getting-started suggestions

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -921,8 +921,9 @@ getting started page
 *****************/
 
 #getting-started .admonition {
-    padding: 25px;
-    margin: 40px auto;
+    padding: 40px;
+    margin: 40px 0 80px 0;
+    max-width: 800px;
 }
 
 #getting-started .admonition.grey {
@@ -942,12 +943,14 @@ getting started page
     padding: 0 25px;
 }
 
-#getting-started .start-step-container .final-notes {
-    padding: 0 25px;
+#getting-started .start-step-container .final-notes h1 {
+    font-weight: 100;
+    max-width: 810px;
+    padding: 3rem 0;
 }
 
-#getting-started .start-step-container .final-notes h3.separator {
-    color: #bdc3c7;
+#getting-started .start-step-container .final-notes h3 ul {
+    list-style: circle;
 }
 
 #getting-started .start-step-container .start-step {
@@ -957,10 +960,14 @@ getting started page
 }
 
 #getting-started .start-step-container .start-step .step-text {
-    width: 60%;
+    width: 50%;
     float: left;
     padding-right: 50px;
     padding-left: 40px;
+}
+
+#getting-started .start-step-container .start-step .step-text h2 {
+    padding-bottom: 0.5em;
 }
 
 #getting-started .start-step-container .start-step .step-text h2 .step-number {

--- a/getting-started.html
+++ b/getting-started.html
@@ -9,8 +9,12 @@ en-only: true
 <h1>Getting Started</h1>
 
 <div class="mt-5 mb-2" id="getting-started">
-    <p>This guide covers just what you need to get trading quickly!</p>
-    <p>Most videos below are just about 2 minutes long. Written documentation is linked below too, if you prefer it. And <a href="https://keybase.io/team/bisq" target="_blank">support</a> is never too far away.</p>
+    <h3>This guide covers just what you need to get trading quickly!</h3>
+    <ul>
+        <li>Most videos below are just about 2 minutes long.</li> 
+        <li>Written documentation is linked below too, if you prefer it.</li>
+        <li><a href="https://keybase.io/team/bisq" target="_blank">support</a> is never too far away.</li>
+    </ul>
 
     <div class="admonition grey">
         <p class="note">Before you can start trading on Bisq, you'll need a little bitcoin for a security deposit and fees (0.01 BTC should be enough). Each trader must lock bitcoin in a multisignature escrow until the trade is complete—this is part of what makes trading on Bisq highly secure.</p>
@@ -100,13 +104,13 @@ en-only: true
             </div>
         </div>
 
-        <div class="final-notes centered">
-            <h3>That's it—the bare essentials of getting started with Bisq.</h3>
-            <h3 class="separator">―</h3>
-            <h3>Browse the <a href="https://bisq.wiki/" target="_blank">wiki</a> and <a href="https://docs.bisq.network/" target="_blank">documentation</a> to learn more.
-            <h3>Or say hi on <a href="https://keybase.io/team/bisq" target="_blank">Keybase</a>.</h3>
-            <h3 class="separator">―</h3>
-            <h3>Or simply make another trade!</h3>
+        <div class="final-notes">
+            <h1>That's it—the bare essentials of getting started with Bisq.</h1>
+            <h3>
+                <ul>
+                    <li>Browse the <a href="https://bisq.wiki/" target="_blank">wiki</a> and <a href="https://docs.bisq.network/" target="_blank">documentation</a> to learn more.</li>
+                    <li>Say hi on <a href="https://keybase.io/team/bisq" target="_blank">Keybase</a>.</li>
+                    <li>Or simply make another trade!</li>
         </div>
 
     </div>


### PR DESCRIPTION
I've implemented the changes suggested in #372.

Only exception: moving the video selectors below the videos. To me, this seemed to make it harder to find the video selector. @pedromvpg what do you think?

Here's a screenshot of the page after the changes proposed in this PR.

![Screenshot_2020-07-28 Getting Started ‹ Bisq - A decentralized bitcoin exchange network](https://user-images.githubusercontent.com/735155/88667350-3f6a3280-d0af-11ea-8a26-8efa102859ec.png)