### PR TITLE
Separate javascript into page-specific files and remove unused code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@
         <script defer src="/js/jquery-3.3.1.min.js"></script>
         <script defer src="/js/popper.min.js"></script>
         <script defer src="/js/bootstrap.min.js"></script>
-        <script defer src="/js/scripts.js"></script>
+        <script defer src="/js/site.js"></script>
 
 {% unless page.layout == "post" %}
         <!-- Schema.org JSON-LD Markup for Search Engine Optimization -->

--- a/_layouts/page_faq.html
+++ b/_layouts/page_faq.html
@@ -1,6 +1,9 @@
 ---
 layout: page
 ---
+
+<script defer src="/js/faq.js"></script>
+
 {% assign item = site.data[page.lang].faq %}
 <div itemscope itemtype="https://schema.org/FAQPage">
   <h1>{{ item.hFAQ }}</h1>

--- a/_layouts/page_home.html
+++ b/_layouts/page_home.html
@@ -2,6 +2,8 @@
 layout: default
 ---
 
+<script defer src="/js/home.js"></script>
+
 {% assign item = site.data[page.lang].homepage_content %}
 <div class="container fadeIn">
         <main class="bd-masthead" id="content" role="main">

--- a/js/faq.js
+++ b/js/faq.js
@@ -1,0 +1,56 @@
+$( document ).ready( function() {
+
+    //FAQ Accordion
+    $('.accordion').each(function() {
+
+        $(this).find('.accordion-toggle').click(function(event) {
+            event.preventDefault();
+
+            $(".accordion-toggle").not($(this)).removeClass('accordion-toggle-active');
+
+            if($(this).hasClass('accordion-toggle-active')){
+                $(this).removeClass('accordion-toggle-active');
+            }else{
+                $(this).addClass('accordion-toggle-active');
+            }
+
+            $(this).next().slideToggle('fast');
+            $(".accordion-content").not($(this).next()).slideUp('fast');
+
+            if($(this).attr('id') !== undefined) {
+                //add hash to url
+                if(history.pushState) {
+                    history.pushState(null, null, '#' + $(this).attr('id'));
+                } else {
+                    location.hash = '#' + $(this).attr('id');
+                }
+            }
+        });
+    });
+
+    if( window.location.hash ) {
+        showAccordionItem();
+    }
+
+    $( ".accordion-content a" ).on( "click", function() {
+        var address = $(this).attr('href');
+        if( address.charAt(0) === '#' ) {
+            showAccordionItem( address );
+        };
+        return;
+    });
+
+    function showAccordionItem( anchorAddress ) {
+
+        var address = anchorAddress ? anchorAddress : window.location.hash;
+
+        $("html, body").animate( {
+            scrollTop: ( $( address ).offset().top - 100 )
+        }, 1000 );
+
+        $( address ).addClass( 'accordion-toggle-active' ).next().slideToggle( 'fast' );
+
+        return;
+    }
+
+});

--- a/js/home.js
+++ b/js/home.js
@@ -1,6 +1,5 @@
 $( document ).ready( function() {
 
-
     /**************************************************
     detect os to show correct download links
     **************************************************/
@@ -73,7 +72,10 @@ $( document ).ready( function() {
         return;
     }
 
-    //How to get started
+    /**************************************************
+    hover actions for the "how to get started" section
+    **************************************************/
+
     $('.step').on({
         mouseenter: function () {
             $('.step').css('opacity', 0.5),
@@ -83,66 +85,4 @@ $( document ).ready( function() {
         },
         mouseout: function () {}
     });
-
-
-    //FAQ Accordion
-    $('.accordion').each(function() {
-
-        $(this).find('.accordion-toggle').click(function(event) {
-            event.preventDefault();
-
-            $(".accordion-toggle").not($(this)).removeClass('accordion-toggle-active');
-
-            if($(this).hasClass('accordion-toggle-active')){
-                $(this).removeClass('accordion-toggle-active');
-            }else{
-                $(this).addClass('accordion-toggle-active');
-            }
-
-            $(this).next().slideToggle('fast');
-            $(".accordion-content").not($(this).next()).slideUp('fast');
-
-            if($(this).attr('id') !== undefined) {
-                //add hash to url
-                if(history.pushState) {
-                    history.pushState(null, null, '#' + $(this).attr('id'));
-                } else {
-                    location.hash = '#' + $(this).attr('id');
-                }
-            }
-        });
-    });
-
-    if( window.location.hash ) {
-        showAccordionItem();
-    }
-
-    $( ".accordion-content a" ).on( "click", function() {
-        var address = $(this).attr('href');
-        if( address.charAt(0) === '#' ) {
-            showAccordionItem( address );
-        };
-        return;
-    });
-
-    function showAccordionItem( anchorAddress ) {
-
-        var address = anchorAddress ? anchorAddress : window.location.hash;
-
-        $("html, body").animate( {
-            scrollTop: ( $( address ).offset().top - 100 )
-        }, 1000 );
-
-        $( address ).addClass( 'accordion-toggle-active' ).next().slideToggle( 'fast' );
-
-        return;
-    }
-
-
-    $( ".mode-toggle" ).on( "click", function() {
-      $("body").toggleClass("dark-mode");
-      $("body").hasClass("dark-mode") ? Cookies.set("darkmode", 1) : Cookies.set("darkmode", 0);
-      return;
-    });
-
 });

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -55,10 +55,6 @@ $( document ).ready( function() {
         }
     });
 
-    $( '.dl-win64, .dl-mac, .dl-deb64, .dl-rpm64' ).on( 'click', function() {
-        sendAnalytic( $(this).attr('class').split('-').pop().split(" ").shift() );
-    });
-
     //change dom to show downloads for the specific os
     function showOSDownloads( os ) {
         $( '.dl-' + os ).addClass( 'selected' );
@@ -72,16 +68,8 @@ $( document ).ready( function() {
             downloadLink = downloadLink.replace( /<site_url_placeholder>/g, siteURL );
         } else {
             downloadLink = downloadLink.replace( /<bisq_version_placeholder>/g, bisqVersion );
-            sendAnalytic( osName );
         }
         location.href = downloadLink;
-        return;
-    }
-
-    //add virtual pageview and event tracking for download attempts
-    function sendAnalytic( platform ) {
-        ga( 'send', 'pageview', location.pathname + 'release' );
-        ga( 'send', 'event', 'Release Build', 'download', platform );
         return;
     }
 

--- a/js/site.js
+++ b/js/site.js
@@ -1,0 +1,13 @@
+$( document ).ready( function() {
+
+    /**************************************************
+    dark mode toggle
+    **************************************************/
+
+    $( ".mode-toggle" ).on( "click", function() {
+      $("body").toggleClass("dark-mode");
+      $("body").hasClass("dark-mode") ? Cookies.set("darkmode", 1) : Cookies.set("darkmode", 0);
+      return;
+    });
+
+});


### PR DESCRIPTION
I wanted to add an anchor link to the front page, but FAQ page JavaScript was getting in the way. 

As it turned out, JavaScript code for the home and FAQ pages was being loaded for _every_ page. This also made load times unnecessarily slower for other pages.

This PR puts JavaScript for the home page in a separate home.js file that is only loaded when the home page is loaded. Likewise for the FAQ page.

Additionally, it removes lingering code from when Google Analytics was used.

Review/test:
https://deploy-preview-381--bisq-website.netlify.app/

## Review Guidance

In this case, there are just 2 commits, so it's worth looking at them separately.
- https://github.com/bisq-network/bisq-website/pull/381/commits/288eef800ee59b97a1b751c122ebc0a050ab96c8 just removes the `sendAnalytic()` function and both lines that call it
  - there isn't much to test here, aside from maybe inspecting the rest of the code base for any lingering mentions of `sendAnalytic()`...since these proposed changes remove that function, that method should not be used anywhere else.
- https://github.com/bisq-network/bisq-website/pull/381/commits/0605baadbdb6e0fb6d52a0672c1406d560719150 separates JavaScript in `/js/scripts.js` into 2 separate files called `/js/home.js` and `/js/faq.js`.
  - one way to test this is to make sure that all dynamic elements on the home page and faq page still work (e.g., accordion expanders on faq page, hover effect on getting-started section of front page, etc)
  - another good check could involve diffing the _site/ folder before and after these proposed changes are put in place. Since nothing visual should have changed, the generated website should be almost identical. To do this, just build the site without proposed changes, build the site with proposed changes, and then compare the result:
    - run `git checkout master`, `rm -rf _site`, and then `bundle exec jekyll build`. 
    - move the resulting `_site` folder somewhere else. 
    - then run `git checkout move-js`, `rm -rf _site`, and then `bundle exec jekyll build`. 
    - compare the resulting `_site` folder with the other one with a diffing tool of your choice (e.g. Meld). 

You should see `js/scripts.js` missing on every page, and `js/home.js` and `js/faq.js` added to all home pages and all faq pages...but everything else should be the same.