### PR TITLE
Update dao image text and ids

### DIFF
--- a/de/images/DAO/dao_benefits.svg
+++ b/de/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(440.002 2554.057)">
         <tspan x="0" y="0">Trading-Gebühren</tspan>
         <tspan x="0" y="17">·</tspan>
       </text>

--- a/de/images/DAO/dao_benefits.svg
+++ b/de/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Trading-Gebühren</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ ausgegeben</tspan>
+        <tspan x="0" y="17">als Kompensation</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/de/images/DAO/dao_benefits.svg
+++ b/de/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg275"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata279">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview277"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.1997063"
-     inkscape:cx="79.797755"
-     inkscape:cy="207.06297"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs253">
-    <style
-       type="text/css"
-       id="style246">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style248">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,105 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect250" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff"
-         x="486.00201"
-         y="2554.0569">
-        <tspan
-           sodipodi:role="line"
-           id="tspan633"
-           x="486.00201"
-           y="2554.0569">Trading</tspan>
-        <tspan
-           sodipodi:role="line"
-           id="tspan635"
-           x="486.00201"
-           y="2572.8069">Gebühren</tspan>
-      </text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan642"
-           x="0"
-           y="0">BSQ ausgegeben</tspan>
-        <tspan
-           sodipodi:role="line"
-           x="0"
-           y="18.75"
-           id="tspan644">als Kompensation</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/de/images/DAO/dao_how.svg
+++ b/de/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Erlösverteilung</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Entscheidungsfindung</tspan>
+    </text>
   </g>
 </svg>

--- a/de/images/DAO/dao_how.svg
+++ b/de/images/DAO/dao_how.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg338"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata342">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview340"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="256.1816"
-     inkscape:cy="341.3306"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how" />
-  <defs
-     id="defs288">
-    <style
-       type="text/css"
-       id="style281">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style283">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -82,329 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect285" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="358.1803"
-       y="70.601997">
-      <tspan
-         x="283.70029"
-         y="70.601997"
-         id="tspan331">Erlösverteilung</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="314.46042"
-       y="617.60199">
-      <tspan
-         x="255.02841"
-         y="617.60199"
-         id="tspan334">Entscheidungsfindung</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/de/images/DAO/dao_intro.svg
+++ b/de/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Mitarbeiter</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Bisq Network</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Trader</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BSQ</tspan>
+          <tspan x="-26.028" y="15">COLORED</tspan>
+          <tspan x="-23.79" y="30">BITCOIN</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Kompensation</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Verbesserungen</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Trading-Gebühren</tspan>
+    </text>
   </g>
 </svg>

--- a/de/images/DAO/dao_intro.svg
+++ b/de/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg415"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata419">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview417"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="273.51275"
-     inkscape:cy="278.45699"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs353">
-    <style
-       type="text/css"
-       id="style344">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style346">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,237 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect350" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path355" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path357" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.835 85)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle361" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle363" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle366" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle368" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle371" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle373" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="340.17078"
-       y="156">
-      <tspan
-         x="301.01077"
-         y="156"
-         id="tspan376">Mitarbeiter</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="523.84485"
-       y="473">
-      <tspan
-         x="477.92484"
-         y="473"
-         id="tspan379">Bisq Netzwerk</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       transform="translate(155.835 473)">
-      <tspan
-         x="-22.512"
-         y="0"
-         id="tspan382">Trader</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan385">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle388" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle390" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           transform="translate(56.326 45.315)">
-          <tspan
-             x="-11.418"
-             y="0"
-             id="tspan393">BSQ</tspan>
-          <tspan
-             x="-26.028"
-             y="15"
-             id="tspan395">COLORED</tspan>
-          <tspan
-             x="-23.79"
-             y="30"
-             id="tspan397">BITCOIN</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       transform="translate(530.835,259)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-50.448002"
-         y="0"
-         id="tspan405">Kompensation</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       transform="translate(142.835,271)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-51.296001"
-         y="0"
-         id="tspan408">Verbesserungen</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       transform="translate(345.835,583)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-44.264"
-         y="0"
-         id="tspan411">Trading Gebühren</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/de/images/DAO/dao_what.svg
+++ b/de/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Mitarbeiter</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Beiträge</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Gebühren</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Trader</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/de/images/DAO/dao_what.svg
+++ b/de/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg462"
-   sodipodi:docname="dao_what.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata466">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview464"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.7503671"
-     inkscape:cx="293.58737"
-     inkscape:cy="55.671264"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs428">
-    <style
-       type="text/css"
-       id="style421">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style423">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,138 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect425" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle430" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle432" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle435" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle437" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="553.40582"
-         y="352.60101">
-        <tspan
-           x="520.30383"
-           y="352.60101"
-           id="tspan440">Mitarbeiter</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="362.28409"
-         y="408.35001">
-        <tspan
-           x="327.03409"
-           y="408.35001"
-           id="tspan443">Beiträge</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="334.86551"
-         y="296.853">
-        <tspan
-           x="322.93149"
-           y="296.853"
-           id="tspan446">Gebühren</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         transform="translate(143.71 352.601)">
-        <tspan
-           x="-20.136"
-           y="0"
-           id="tspan449">Traders</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan457">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/de/images/DAO/dao_why.svg
+++ b/de/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Dezentrale Governance </tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Zentralisierte Fehlerstelle</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Ohne DAO</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">Mit DAO</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Mitarbeiter</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Trader</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/de/images/DAO/dao_why.svg
+++ b/de/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg1568"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1572">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1570"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3817562"
-     inkscape:cx="169.23587"
-     inkscape:cy="188.38314"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs1349">
-    <style
-       type="text/css"
-       id="style1342">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1344">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,953 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect1346" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1367" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1369" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1372" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1374" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1377" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1379" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1382" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1384" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1387" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1389" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1392" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1394" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1397" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1399" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1418" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1420" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1423" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1425" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle1428" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle1430" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1433" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1435" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1438" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1440" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1443" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1445" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1448" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1450" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1453" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1455" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1458" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1460" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1463" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1465" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1485" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1487" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1490" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1492" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1495" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1497" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1500" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1502" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1505" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1507" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1510" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1512" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1515" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1517" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle1522" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle1524" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="485.6611"
-         y="511">
-        <tspan
-           x="416.07309"
-           y="511"
-           id="tspan1527">Dezentrale Governance </tspan>
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5"
-         x="168.15218"
-         y="511">
-        <tspan
-           x="97.03418"
-           y="511"
-           id="tspan1530">Zentralisierte Fehlerstelle</tspan>
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="177.45056"
-         y="166">
-        <tspan
-           x="116.85156"
-           y="166"
-           id="tspan1533">Ohne DAO</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="487.66705"
-         y="166">
-        <tspan
-           x="442.53403"
-           y="166"
-           id="tspan1536">Mit DAO</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="330.07733"
-         y="298">
-        <tspan
-           x="296.97534"
-           y="298"
-           id="tspan1539">Mitarbeiter</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         transform="translate(329 351)">
-        <tspan
-           x="-20.136"
-           y="0"
-           id="tspan1542">Traders</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1545">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1548">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1551">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="411.59351"
-         x1="249.59349"
-         y1="320.5"
-         y2="320.5"
-         style="fill:none;stroke:#ffffff;stroke-width:0.5px" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1557">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1560">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1563">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/es/images/DAO/dao_benefits.svg
+++ b/es/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(450.002 2554.057)">
         <tspan x="0" y="0">Comisiones</tspan>
         <tspan x="0" y="17">de Intercambio</tspan>
       </text>

--- a/es/images/DAO/dao_benefits.svg
+++ b/es/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg341"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata345">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview343"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.6966409"
-     inkscape:cx="419.92583"
-     inkscape:cy="379.33459"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs319">
-    <style
-       type="text/css"
-       id="style312">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style314">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,107 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect316" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         x="446.00201"
-         y="2554.0569"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan1211"
-           x="446.00201"
-           y="2554.0569">Comisiones</tspan>
-        <tspan
-           sodipodi:role="line"
-           id="tspan1213"
-           x="446.00201"
-           y="2572.8069">de Intercambio</tspan>
-      </text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:0.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan1237"
-           style="font-size:15px;line-height:0.25"
-           x="0"
-           y="0">BSQ emitidos</tspan>
-        <tspan
-           sodipodi:role="line"
-           style="font-size:15px;line-height:0.25"
-           x="0"
-           y="13.369141"
-           id="tspan1241">para compensaciones</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/es/images/DAO/dao_benefits.svg
+++ b/es/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Comisiones</tspan>
+        <tspan x="0" y="17">de Intercambio</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ emitidos</tspan>
+        <tspan x="0" y="17">para compensaciones</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/es/images/DAO/dao_how.svg
+++ b/es/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Distribución de ingresos</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Toma de decisiones</tspan>
+    </text>
   </g>
 </svg>

--- a/es/images/DAO/dao_how.svg
+++ b/es/images/DAO/dao_how.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg291"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata295">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview293"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.98018913"
-     inkscape:cx="288.99648"
-     inkscape:cy="377.43268"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how" />
-  <defs
-     id="defs241">
-    <style
-       type="text/css"
-       id="style234">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style236">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -82,329 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect238" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="319.11359"
-       y="70.601997">
-      <tspan
-         x="244.63359"
-         y="70.601997"
-         id="tspan284">Distribución de ingresos</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="323.28043"
-       y="617.60199">
-      <tspan
-         x="263.84842"
-         y="617.60199"
-         id="tspan287">Toma de decisiones</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/es/images/DAO/dao_intro.svg
+++ b/es/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Contribuyente</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Red Bisq</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Comerciante</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BSQ</tspan>
+          <tspan x="-26.028" y="15">BITCOIN</tspan>
+          <tspan x="-23.79" y="30">COLOREADO</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Compensación</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Mejoras</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Comisiones de Intercambio</tspan>
+    </text>
   </g>
 </svg>

--- a/es/images/DAO/dao_intro.svg
+++ b/es/images/DAO/dao_intro.svg
@@ -85,13 +85,13 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(335.835 156)">
       <tspan x="-39.16" y="0">Contribuyente</tspan>
     </text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(547.835 473)">
       <tspan x="-45.92" y="0">Red Bisq</tspan>
     </text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+    <text id="dao_intro_trader" class="cls-6" transform="translate(135.835 473)">
       <tspan x="-22.512" y="0">Comerciante</tspan>
     </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
@@ -105,7 +105,7 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+BITCOIN" class="cls-8" transform="translate(51.326 45.315)">
           <tspan x="-11.418" y="0">BSQ</tspan>
           <tspan x="-26.028" y="15">BITCOIN</tspan>
           <tspan x="-23.79" y="30">COLOREADO</tspan>
@@ -121,7 +121,7 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
     <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
       <tspan x="-51.296" y="0">Mejoras</tspan>
     </text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(330.835 593)">
       <tspan x="-44.264" y="0">Comisiones de Intercambio</tspan>
     </text>
   </g>

--- a/es/images/DAO/dao_intro.svg
+++ b/es/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg198"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata202">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview200"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.1997063"
-     inkscape:cx="238.69083"
-     inkscape:cy="346.94322"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs136">
-    <style
-       type="text/css"
-       id="style127">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style129">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,249 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect133" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path138" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path140" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.835 85)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle144" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle146" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle149" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle151" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle154" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle156" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="327.79968"
-       y="156">
-      <tspan
-         x="288.63968"
-         y="156"
-         id="tspan159">Contribuyente</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="546.99329"
-       y="473">
-      <tspan
-         x="501.07327"
-         y="473"
-         id="tspan162">Red Bisq</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="127.32356"
-       y="473">
-      <tspan
-         x="104.81156"
-         y="473"
-         id="tspan165">Comerciante</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan168">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle171" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle173" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif"
-           x="56.101002"
-           y="45.458164">
-          <tspan
-             sodipodi:role="line"
-             id="tspan212"
-             x="56.101002"
-             y="45.458164"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle">BSQ</tspan>
-          <tspan
-             sodipodi:role="line"
-             id="tspan214"
-             x="56.101002"
-             y="60.458164"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle">BITCOIN</tspan>
-          <tspan
-             sodipodi:role="line"
-             x="56.101002"
-             y="75.458168"
-             id="tspan216"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle">COLOREADO</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       transform="translate(530.835,259)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-50.448002"
-         y="0"
-         id="tspan188">Compensación</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="170.83501"
-       y="271">
-      <tspan
-         x="119.539"
-         y="271"
-         id="tspan191">Mejoras</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="281.11462"
-       y="583">
-      <tspan
-         x="236.85063"
-         y="583"
-         id="tspan194">Comisiones de Intercambio</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/es/images/DAO/dao_what.svg
+++ b/es/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg242"
-   sodipodi:docname="dao_what_es.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata246">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview244"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.948605"
-     inkscape:cx="340.5"
-     inkscape:cy="132"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs208">
-    <style
-       type="text/css"
-       id="style201">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style203">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,140 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect205" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle210" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle212" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle215" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle217" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="542.89703"
-         y="352.60101">
-        <tspan
-           x="509.79504"
-           y="352.60101"
-           id="tspan220">Contribuidores</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="342.51566"
-         y="408.35001">
-        <tspan
-           x="307.26566"
-           y="408.35001"
-           id="tspan223">Contribuciones</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="329.78171"
-         y="296.853">
-        <tspan
-           x="317.84769"
-           y="296.853"
-           id="tspan226">Comisiones</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="123.46308"
-         y="352.60101">
-        <tspan
-           x="103.32708"
-           y="352.60101"
-           id="tspan229">Comerciantes</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan237">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/es/images/DAO/dao_what.svg
+++ b/es/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Contribuidores</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Contribuciones</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Comisiones</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Comerciantes</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/es/images/DAO/dao_why.svg
+++ b/es/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg760"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata764">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview762"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3817562"
-     inkscape:cx="191.7703"
-     inkscape:cy="181.48835"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs541">
-    <style
-       type="text/css"
-       id="style534">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style536">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,952 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect538" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle559" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle561" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle564" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle566" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle569" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle571" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle574" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle576" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle579" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle581" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle584" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle586" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle589" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle591" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle610" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle612" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle615" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle617" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle620" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle622" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle625" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle627" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle630" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle632" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle635" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle637" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle640" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle642" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle645" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle647" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle650" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle652" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle655" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle657" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle677" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle679" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle682" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle684" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle687" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle689" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle692" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle694" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle697" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle699" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle702" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle704" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle707" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle709" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle714" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle716" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="471.60153"
-         y="511">
-        <tspan
-           x="402.01352"
-           y="511"
-           id="tspan719">Gobernanza descentralizada</tspan>
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5"
-         x="163.04573"
-         y="511">
-        <tspan
-           x="91.927734"
-           y="511"
-           id="tspan722">Punto Centralizado de Fallo</tspan>
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="189.71814"
-         y="166">
-        <tspan
-           x="129.11914"
-           y="166"
-           id="tspan725">Sin DAO</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="483.59576"
-         y="166">
-        <tspan
-           x="438.46274"
-           y="166"
-           id="tspan728">Con DAO</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="323.73331"
-         y="298">
-        <tspan
-           x="290.63132"
-           y="298"
-           id="tspan731">Contribuidores</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="313.47433"
-         y="351">
-        <tspan
-           x="293.33835"
-           y="351"
-           id="tspan734">Comerciantes</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan737">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan740">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan743">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="162"
-         transform="translate(247.5 320.5)" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan749">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan752">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan755">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/es/images/DAO/dao_why.svg
+++ b/es/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Gobernanza descentralizada</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Punto Centralizado de Fallo</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Sin DAO</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">Con DAO</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Contribuidores</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Comerciantes</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/fr/images/DAO/dao_benefits.svg
+++ b/fr/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg276"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata280">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview278"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="518.31288"
-     inkscape:cy="199.91014"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs254">
-    <style
-       type="text/css"
-       id="style247">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style249">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,105 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect251" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="500.00201"
-         y="2554.0569">
-        <tspan
-           sodipodi:role="line"
-           id="tspan286"
-           x="500.00201"
-           y="2554.0569">Frais de</tspan>
-        <tspan
-           sodipodi:role="line"
-           id="tspan288"
-           x="500.00201"
-           y="2572.8069">Trading</tspan>
-      </text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan290"
-           x="0"
-           y="0">BSQ émis pour</tspan>
-        <tspan
-           sodipodi:role="line"
-           id="tspan292"
-           x="0"
-           y="18.75">en compensations</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/fr/images/DAO/dao_benefits.svg
+++ b/fr/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Frais</tspan>
+        <tspan x="0" y="17">de Trading</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ émis</tspan>
+        <tspan x="0" y="17">pour en compensations</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/fr/images/DAO/dao_benefits.svg
+++ b/fr/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(480.002 2554.057)">
         <tspan x="0" y="0">Frais</tspan>
         <tspan x="0" y="17">de Trading</tspan>
       </text>

--- a/fr/images/DAO/dao_how.svg
+++ b/fr/images/DAO/dao_how.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg457"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata461">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview459"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.98018913"
-     inkscape:cx="361.68116"
-     inkscape:cy="381.96526"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how" />
-  <defs
-     id="defs407">
-    <style
-       type="text/css"
-       id="style400">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style402">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -82,329 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect404" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="322.78577"
-       y="70.601997">
-      <tspan
-         x="248.30576"
-         y="70.601997"
-         id="tspan450">Répartition des revenus</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="336.04636"
-       y="617.60199">
-      <tspan
-         x="276.61435"
-         y="617.60199"
-         id="tspan453">Prise de décision</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/fr/images/DAO/dao_how.svg
+++ b/fr/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Répartition des revenus</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Prise de décision</tspan>
+    </text>
   </g>
 </svg>

--- a/fr/images/DAO/dao_intro.svg
+++ b/fr/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Contributeur</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Réseau Bisq</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Trader</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BSQ</tspan>
+          <tspan x="-26.028" y="15">COLORED</tspan>
+          <tspan x="-23.79" y="30">BITCOIN</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Compensation</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Améliorations</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Frais de Trading</tspan>
+    </text>
   </g>
 </svg>

--- a/fr/images/DAO/dao_intro.svg
+++ b/fr/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg654"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata658">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview656"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="338.55935"
-     inkscape:cy="341.29567"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs592">
-    <style
-       type="text/css"
-       id="style583">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style585">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,240 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect589" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path594" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path596" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.835 85)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle600" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle602" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle605" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle607" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle610" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle612" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="333.74109"
-       y="156">
-      <tspan
-         x="294.58109"
-         y="156"
-         id="tspan615">Contributeur</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="532.99329"
-       y="473">
-      <tspan
-         x="487.07327"
-         y="473"
-         id="tspan618">Réseau Bisq</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       x="153.1595"
-       y="473"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="130.64751"
-         y="473"
-         id="tspan621">Trader</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan624">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle627" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle629" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           transform="translate(56.326 45.315)">
-          <tspan
-             x="-11.418"
-             y="0"
-             id="tspan632">BSQ</tspan>
-          <tspan
-             x="-26.028"
-             y="15"
-             id="tspan634">COLORED</tspan>
-          <tspan
-             x="-23.79"
-             y="30"
-             id="tspan636">BITCOIN</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       transform="translate(530.835,259)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-50.448002"
-         y="0"
-         id="tspan644">Compensation</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       transform="translate(142.835,271)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-51.296001"
-         y="0"
-         id="tspan647">Améliorations</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="326.94666"
-       y="583">
-      <tspan
-         x="282.68265"
-         y="583"
-         id="tspan650">Frais de Trading</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/fr/images/DAO/dao_what.svg
+++ b/fr/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg791"
-   sodipodi:docname="dao_what.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata795">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview793"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.2376965"
-     inkscape:cx="230.14933"
-     inkscape:cy="53.956243"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs757">
-    <style
-       type="text/css"
-       id="style750">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style752">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,135 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect754" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle759" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle761" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle764" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle766" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         transform="translate(552.211,352.601)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-33.102001"
-           y="0"
-           id="tspan769">Contributeurs</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         transform="translate(348.835,408.35)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-35.25"
-           y="0"
-           id="tspan772">Contributions</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         transform="translate(348.835,296.853)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-11.934"
-           y="0"
-           id="tspan775">Frais</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         transform="translate(143.71 352.601)">
-        <tspan
-           x="-20.136"
-           y="0"
-           id="tspan778">Traders</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan786">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/fr/images/DAO/dao_what.svg
+++ b/fr/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Contributeurs</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Contributions</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Frais</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Traders</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/fr/images/DAO/dao_why.svg
+++ b/fr/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Gouvernance décentralisée</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Point de rupture centralisé</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Sans la DAO</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">Avec le DAO</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Contributeurs</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Traders</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/fr/images/DAO/dao_why.svg
+++ b/fr/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg1298"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1302">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1300"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3817562"
-     inkscape:cx="300.1275"
-     inkscape:cy="143.97194"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs1079">
-    <style
-       type="text/css"
-       id="style1072">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1074">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,950 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect1076" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1097" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1099" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1102" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1104" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1107" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1109" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1112" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1114" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1117" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1119" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1122" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1124" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1127" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1129" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1148" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1150" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1153" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1155" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle1158" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle1160" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1163" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1165" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1168" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1170" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1173" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1175" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1178" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1180" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1183" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1185" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1188" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1190" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1193" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1195" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1215" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1217" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1220" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1222" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1225" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1227" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1230" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1232" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1235" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1237" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1240" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1242" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1245" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1247" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle1252" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle1254" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="474.59567"
-         y="511">
-        <tspan
-           x="405.00766"
-           y="511"
-           id="tspan1257">Gouvernance décentralisée</tspan>
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5"
-         x="164.96175"
-         y="511">
-        <tspan
-           x="93.84375"
-           y="511"
-           id="tspan1260">Point de rupture centralisé</tspan>
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="166.98767"
-         y="166">
-        <tspan
-           x="106.38867"
-           y="166"
-           id="tspan1263">Sans la DAO</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="466.01617"
-         y="166">
-        <tspan
-           x="420.88315"
-           y="166"
-           id="tspan1266">Avec la DAO</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="322.6322"
-         y="298">
-        <tspan
-           x="289.53021"
-           y="298"
-           id="tspan1269">Contributeurs</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         transform="translate(329 351)">
-        <tspan
-           x="-20.136"
-           y="0"
-           id="tspan1272">Traders</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1275">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1278">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1281">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="162"
-         transform="translate(247.5 320.5)" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1287">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1290">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1293">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/images/DAO/dao_benefits.svg
+++ b/images/DAO/dao_benefits.svg
@@ -46,9 +46,9 @@
   </defs>
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
-      <text id="Trading_fees" data-name="Trading
+      <text id="dao_benefits_burn" data-name="Trading
 fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
-      <text id="BSQ_issued_for_compensations" data-name="BSQ issued
+      <text id="dao_benefits_issuance" data-name="BSQ issued
 for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>

--- a/images/DAO/dao_how.svg
+++ b/images/DAO/dao_how.svg
@@ -79,7 +79,7 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="Revenue-distribution" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="Decision-making" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/images/DAO/dao_intro.svg
+++ b/images/DAO/dao_intro.svg
@@ -87,9 +87,9 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="Contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="Bisq_Network" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="Trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
       <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
@@ -97,7 +97,7 @@
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
           <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text id="BSQ_COLORED_BITCOIN" data-name="BSQ
+        <text id="dao_intro_bsq" data-name="BSQ
 COLORED
 BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
@@ -105,8 +105,8 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="Compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="Improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="Trading_Fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/images/DAO/dao_what.svg
+++ b/images/DAO/dao_what.svg
@@ -67,10 +67,10 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="Contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="Contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="Fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="Traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>

--- a/images/DAO/dao_why.svg
+++ b/images/DAO/dao_why.svg
@@ -238,12 +238,12 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="Decentralized_Governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="Centralized_Point_of_Failure" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="Without_DAO" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="With_DAO" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="Contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="Traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>

--- a/ja/images/DAO/dao_benefits.svg
+++ b/ja/images/DAO/dao_benefits.svg
@@ -46,10 +46,10 @@
   </defs>
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
-      <text id="Trading_fees" data-name="Trading
-fees" class="cls-2" transform="translate(460.002 2554.057)"><tspan x="0" y="0">トレード手数料</tspan><tspan x="0" y="17"></tspan></text>
-      <text id="BSQ_issued_for_compensations" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">補償のために発行されるBSQ</tspan><tspan x="0" y="17"></tspan></text>
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/ja/images/DAO/dao_benefits.svg
+++ b/ja/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(460.002 2554.057)">
         <tspan x="0" y="0">トレード手数料</tspan>
         <tspan x="0" y="17">·</tspan>
       </text>

--- a/ja/images/DAO/dao_benefits.svg
+++ b/ja/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">トレード手数料</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">補償のために発行されるBSQ ·</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/ja/images/DAO/dao_how.svg
+++ b/ja/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">収益分配</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">意思決定</tspan>
+    </text>
   </g>
 </svg>

--- a/ja/images/DAO/dao_how.svg
+++ b/ja/images/DAO/dao_how.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
-    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');</style>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
 
     <style>
       .cls-1 {
@@ -26,8 +26,8 @@
       }
 
       .cls-5 {
-        font-size: 30px;
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-size: 16px;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 300;
       }
     </style>
@@ -79,7 +79,7 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="Revenue-distribution" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-60" y="0">収益分配</tspan></text>
-    <text id="Decision-making" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-60" y="0">意思決定</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/ja/images/DAO/dao_intro.svg
+++ b/ja/images/DAO/dao_intro.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
-    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');</style>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
 
 
     <style>
@@ -33,11 +33,11 @@
       }
 
       .cls-6 {
-        font-size: 19px;
+        font-size: 16px;
       }
 
       .cls-6, .cls-7 {
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 200;
       }
 
@@ -49,7 +49,7 @@
       .cls-8 {
         fill: rgba(255,255,255,0.56);
         font-size: 12px;
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 300;
       }
 
@@ -87,9 +87,9 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="Contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-25.16" y="0">貢献者</tspan></text>
-    <text id="Bisq_Network" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-57.00" y="0">Bisq Network</tspan></text>
-    <text id="Trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-27.512" y="0">取引者</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
       <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
@@ -97,7 +97,7 @@
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
           <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text id="BSQ_COLORED_BITCOIN" data-name="BSQ
+        <text id="dao_intro_bsq" data-name="BSQ
 COLORED
 BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
@@ -105,8 +105,8 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="Compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-12.448" y="0">補償</tspan></text>
-    <text id="Improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-12.296" y="3">改善</tspan></text>
-    <text id="Trading_Fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-64.264" y="0">トレード手数料</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/ja/images/DAO/dao_intro.svg
+++ b/ja/images/DAO/dao_intro.svg
@@ -85,7 +85,7 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(360.835 156)">
       <tspan x="-39.16" y="0">貢献者</tspan>
     </text>
     <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
@@ -105,7 +105,7 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+BITCOIN" class="cls-8" transform="translate(51.326 45.315)">
           <tspan x="-11.418" y="0">BSQ</tspan>
           <tspan x="-26.028" y="15">カラード</tspan>
           <tspan x="-23.79" y="30">ビットコイン</tspan>
@@ -115,10 +115,10 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(560.835 259)">
       <tspan x="-50.448" y="0">補償</tspan>
     </text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(172.835 271)">
       <tspan x="-51.296" y="0">改善</tspan>
     </text>
     <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">

--- a/ja/images/DAO/dao_intro.svg
+++ b/ja/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">貢献者</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Bisqネットワーク</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">取引者</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BSQ</tspan>
+          <tspan x="-26.028" y="15">カラード</tspan>
+          <tspan x="-23.79" y="30">ビットコイン</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">補償</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">改善</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">トレード手数料</tspan>
+    </text>
   </g>
 </svg>

--- a/ja/images/DAO/dao_what.svg
+++ b/ja/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">貢献者</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">貢献</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">手数料</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">取引者</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/ja/images/DAO/dao_what.svg
+++ b/ja/images/DAO/dao_what.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
 
-    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');</style>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
 
 
     <style>
@@ -22,16 +22,16 @@
       }
 
       .cls-3, .cls-4 {
-        font-size: 22px;
+        font-size: 12px;
         font-weight: 300;
       }
 
       .cls-3 {
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
       }
 
       .cls-4 {
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-style: italic;
       }
 
@@ -45,7 +45,7 @@
 
       .cls-7 {
         font-size: 30px;
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 200;
       }
 
@@ -67,10 +67,10 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="Contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">貢献者</tspan></text>
-      <text id="Contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-25.25" y="0">貢献</tspan></text>
-      <text id="Fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-27.934" y="0">手数料</tspan></text>
-      <text id="Traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-27.136" y="0">取引者</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>

--- a/ja/images/DAO/dao_why.svg
+++ b/ja/images/DAO/dao_why.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
-    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c');</style>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
 
     <style>
       .cls-1 {
@@ -38,8 +38,8 @@
       }
 
       .cls-7, .cls-8 {
-        font-size: 18px;
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-size: 12px;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 300;
       }
 
@@ -49,17 +49,17 @@
 
       .cls-9 {
         font-size: 22px;
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
         font-weight: 200;
       }
 
       .cls-10 {
-        font-size: 14px;
+        font-size: 9px;
         opacity: 0.278;
       }
 
       .cls-10, .cls-12 {
-        font-family: 'M PLUS Rounded 1c', sans-serif;
+        font-family: 'IBM Plex Sans', sans-serif;
       }
 
       .cls-11 {
@@ -238,12 +238,12 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="Decentralized_Governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-103.588" y="0">非中央集権型のガバナンス</tspan></text>
-      <text id="Centralized_Point_of_Failure" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-99.118" y="0">中央集権化された障害点</tspan></text>
-      <text id="Without_DAO" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-42.599" y="0">DAOなし</tspan></text>
-      <text id="With_DAO" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-38.133" y="0">DAOあり</tspan></text>
-      <text id="Contributors" class="cls-7" transform="translate(329 298)"><tspan x="-20.136" y="0">貢献者</tspan></text>
-      <text id="Traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">取引者</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>

--- a/ja/images/DAO/dao_why.svg
+++ b/ja/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">非中央集権型のガバナンス</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">中央集権化された障害点</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">DAOなし</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">DAOあり</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">貢献者</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">取引者</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_benefits.svg
+++ b/pt-BR/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Taxas</tspan>
+        <tspan x="0" y="17">de Negociação</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ emitido</tspan>
+        <tspan x="0" y="17">para compensações</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/pt-BR/images/DAO/dao_benefits.svg
+++ b/pt-BR/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg4110"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata4114">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview4112"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.49009457"
-     inkscape:cx="909.88783"
-     inkscape:cy="500.64149"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs4088">
-    <style
-       type="text/css"
-       id="style4081">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style4083">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,105 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect4085" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="472.00201"
-         y="2554.0569">
-        <tspan
-           sodipodi:role="line"
-           id="tspan4661"
-           x="472.00201"
-           y="2554.0569">Taxa de</tspan>
-        <tspan
-           sodipodi:role="line"
-           x="472.00201"
-           y="2572.8069"
-           id="tspan4665">negociação</tspan>
-      </text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan4667"
-           x="0"
-           y="0">BSQ emitido</tspan>
-        <tspan
-           sodipodi:role="line"
-           x="0"
-           y="18.75"
-           id="tspan4669">para compensações</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_benefits.svg
+++ b/pt-BR/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(460.002 2554.057)">
         <tspan x="0" y="0">Taxas</tspan>
         <tspan x="0" y="17">de Negociação</tspan>
       </text>

--- a/pt-BR/images/DAO/dao_how.svg
+++ b/pt-BR/images/DAO/dao_how.svg
@@ -1,61 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg1566"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1570">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1568"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.98018913"
-     inkscape:cx="335.32743"
-     inkscape:cy="360.92505"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how"
-     showguides="true"
-     inkscape:guide-bbox="true" />
-  <defs
-     id="defs1516">
-    <style
-       type="text/css"
-       id="style1509">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1511">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -84,331 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect1513" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       x="253.51669"
-       y="70.601997"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         sodipodi:role="line"
-         id="tspan3203"
-         x="253.51669"
-         y="70.601997">Distribuição de receita</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       x="267.74716"
-       y="617.60199"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         sodipodi:role="line"
-         id="tspan3205"
-         x="267.74716"
-         y="617.60199">Tomada de decisão</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_how.svg
+++ b/pt-BR/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Distribuição de receita</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Tomando decisão</tspan>
+    </text>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_intro.svg
+++ b/pt-BR/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Contribuidor</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Rede Bisq</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Negociador</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BITCOIN</tspan>
+          <tspan x="-26.028" y="15">COLORIDO</tspan>
+          <tspan x="-23.79" y="30">BSQ</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Compensação</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Melhorias</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Taxas de Negociação</tspan>
+    </text>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_intro.svg
+++ b/pt-BR/images/DAO/dao_intro.svg
@@ -88,10 +88,10 @@
     <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
       <tspan x="-39.16" y="0">Contribuidor</tspan>
     </text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(547.835 473)">
       <tspan x="-45.92" y="0">Rede Bisq</tspan>
     </text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+    <text id="dao_intro_trader" class="cls-6" transform="translate(145.835 473)">
       <tspan x="-22.512" y="0">Negociador</tspan>
     </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
@@ -106,7 +106,7 @@
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
 BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
-          <tspan x="-11.418" y="0">BITCOIN</tspan>
+          <tspan x="-21.418" y="0">BITCOIN</tspan>
           <tspan x="-26.028" y="15">COLORIDO</tspan>
           <tspan x="-23.79" y="30">BSQ</tspan>
         </text>

--- a/pt-BR/images/DAO/dao_intro.svg
+++ b/pt-BR/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg7226"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata7230">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview7228"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="483.10918"
-     inkscape:cy="174.48856"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs7164">
-    <style
-       type="text/css"
-       id="style7155">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style7157">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,250 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect7161" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path7166" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path7168" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.83499,85)"
-       style="fill:#26b036;stroke:#ffffff">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7172"
-         style="stroke:none" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7174"
-         style="fill:none" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7177" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7179" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7182" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7184" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       x="335.23718"
-       y="156"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="296.07718"
-         y="156"
-         id="tspan7187">Contribuinte</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="542.07141"
-       y="470.41406">
-      <tspan
-         x="496.1514"
-         y="470.41406"
-         id="tspan7190">Rede Bisq</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="132.44075"
-       y="473">
-      <tspan
-         x="109.92875"
-         y="473"
-         id="tspan7193">Negociante</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan7196">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle7199" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle7201" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           transform="translate(56.326,45.315)"
-           style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start">
-          <tspan
-             sodipodi:role="line"
-             id="tspan7787"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="0">BITCOIN</tspan>
-          <tspan
-             sodipodi:role="line"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="15"
-             id="tspan9250">COLORIDO</tspan>
-          <tspan
-             sodipodi:role="line"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="30"
-             id="tspan9246">BSQ</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       transform="translate(530.835,259)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-50.448002"
-         y="0"
-         id="tspan7216">Compensação</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       transform="translate(142.835,271)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-51.296001"
-         y="0"
-         id="tspan7219">Melhoramento</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="306.57166"
-       y="583">
-      <tspan
-         x="262.30765"
-         y="583"
-         id="tspan7222">Taxas de Negociação</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_what.svg
+++ b/pt-BR/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Contribuidores</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Contribuições</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Taxas</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Negociadores</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_what.svg
+++ b/pt-BR/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg1426"
-   sodipodi:docname="dao_what.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1430">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1428"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.7503671"
-     inkscape:cx="275.03154"
-     inkscape:cy="123.82337"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs1392">
-    <style
-       type="text/css"
-       id="style1385">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1387">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,137 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect1389" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle1394" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle1396" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle1399" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle1401" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         transform="translate(552.211,352.601)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-33.102001"
-           y="0"
-           id="tspan1404">Contribuintes</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         transform="translate(348.835,408.35)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-35.25"
-           y="0"
-           id="tspan1407">Contribuições</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         transform="translate(348.835,296.853)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-11.934"
-           y="0"
-           id="tspan1410">Taxas</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="129.71001"
-         y="352.60101">
-        <tspan
-           x="109.574"
-           y="352.60101"
-           id="tspan1413">Negociantes</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan1421">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_why.svg
+++ b/pt-BR/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Governança Descentralizada</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Ponto de falha centralizado</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Sem DAO</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">Com DAO</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Contribuidores</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Negociadores</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/pt-BR/images/DAO/dao_why.svg
+++ b/pt-BR/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg1379"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1383">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1381"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="2.0123153"
-     inkscape:cx="244.37332"
-     inkscape:cy="282.5104"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs1160">
-    <style
-       type="text/css"
-       id="style1153">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1155">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,956 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect1157" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1178" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1180" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1183" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1185" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1188" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1190" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1193" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1195" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1198" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1200" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1203" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1205" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1208" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1210" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1229" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1231" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1234" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1236" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle1239" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle1241" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1244" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1246" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1249" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1251" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1254" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1256" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1259" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1261" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1264" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1266" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1269" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1271" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1274" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1276" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1296" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1298" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1301" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1303" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1306" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1308" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1311" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1313" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1316" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1318" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1321" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1323" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1326" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1328" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle1333" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle1335" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         transform="translate(487.835,511)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-69.587997"
-           y="0"
-           id="tspan1338">Governação Descentralizada</tspan>
-        <tspan
-           x="-69.587997"
-           y="0"
-           id="tspan3213" />
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         transform="translate(173.835,511)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5">
-        <tspan
-           x="-71.117996"
-           y="0"
-           id="tspan1341">Ponto de Falha Centralizado</tspan>
-        <tspan
-           x="-71.117996"
-           y="0"
-           id="tspan3211" />
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         transform="translate(174,166)"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-60.598999"
-           y="0"
-           id="tspan1344">Sem OAD</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         transform="translate(485,166)"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-45.132999"
-           y="0"
-           id="tspan1347">Com OAD</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="328.13129"
-         y="298">
-        <tspan
-           x="295.0293"
-           y="298"
-           id="tspan1350">Contribuintes</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="318.05396"
-         y="351">
-        <tspan
-           x="297.91797"
-           y="351"
-           id="tspan1353">Negociantes</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1356">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1359">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1362">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="162"
-         transform="translate(247.5 320.5)" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1368">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1371">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1374">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_benefits.svg
+++ b/pt-PT/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Taxa</tspan>
+        <tspan x="0" y="17">de negociação</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ emitido</tspan>
+        <tspan x="0" y="17">para compensações</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/pt-PT/images/DAO/dao_benefits.svg
+++ b/pt-PT/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(460.002 2554.057)">
         <tspan x="0" y="0">Taxa</tspan>
         <tspan x="0" y="17">de negociação</tspan>
       </text>

--- a/pt-PT/images/DAO/dao_benefits.svg
+++ b/pt-PT/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg4110"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata4114">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview4112"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.49009457"
-     inkscape:cx="909.88783"
-     inkscape:cy="500.64149"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs4088">
-    <style
-       type="text/css"
-       id="style4081">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style4083">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,105 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect4085" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="472.00201"
-         y="2554.0569">
-        <tspan
-           sodipodi:role="line"
-           id="tspan4661"
-           x="472.00201"
-           y="2554.0569">Taxa de</tspan>
-        <tspan
-           sodipodi:role="line"
-           x="472.00201"
-           y="2572.8069"
-           id="tspan4665">negociação</tspan>
-      </text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan4667"
-           x="0"
-           y="0">BSQ emitido</tspan>
-        <tspan
-           sodipodi:role="line"
-           x="0"
-           y="18.75"
-           id="tspan4669">para compensações</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_how.svg
+++ b/pt-PT/images/DAO/dao_how.svg
@@ -1,61 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg1566"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1570">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1568"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.98018913"
-     inkscape:cx="335.32743"
-     inkscape:cy="360.92505"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how"
-     showguides="true"
-     inkscape:guide-bbox="true" />
-  <defs
-     id="defs1516">
-    <style
-       type="text/css"
-       id="style1509">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1511">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -84,331 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect1513" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       x="253.51669"
-       y="70.601997"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         sodipodi:role="line"
-         id="tspan3203"
-         x="253.51669"
-         y="70.601997">Distribuição de receita</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       x="267.74716"
-       y="617.60199"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         sodipodi:role="line"
-         id="tspan3205"
-         x="267.74716"
-         y="617.60199">Tomada de decisão</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_how.svg
+++ b/pt-PT/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Distribuição de receita</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Tomada de decisão</tspan>
+    </text>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_intro.svg
+++ b/pt-PT/images/DAO/dao_intro.svg
@@ -88,10 +88,10 @@
     <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
       <tspan x="-39.16" y="0">Contribuinte</tspan>
     </text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(547.835 473)">
       <tspan x="-45.92" y="0">Rede Bisq</tspan>
     </text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+    <text id="dao_intro_trader" class="cls-6" transform="translate(145.835 473)">
       <tspan x="-22.512" y="0">Negociador</tspan>
     </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
@@ -106,7 +106,7 @@
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
 BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
-          <tspan x="-11.418" y="0">BITCOIN</tspan>
+          <tspan x="-21.418" y="0">BITCOIN</tspan>
           <tspan x="-26.028" y="15">COLORIDO</tspan>
           <tspan x="-23.79" y="30">BSQ</tspan>
         </text>

--- a/pt-PT/images/DAO/dao_intro.svg
+++ b/pt-PT/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Contribuinte</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Rede Bisq</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Negociador</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BITCOIN</tspan>
+          <tspan x="-26.028" y="15">COLORIDO</tspan>
+          <tspan x="-23.79" y="30">BSQ</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Compensação</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Melhoramento</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Taxa de negociação</tspan>
+    </text>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_intro.svg
+++ b/pt-PT/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg7226"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata7230">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview7228"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="483.10918"
-     inkscape:cy="174.48856"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs7164">
-    <style
-       type="text/css"
-       id="style7155">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style7157">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,250 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect7161" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path7166" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path7168" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.83499,85)"
-       style="fill:#26b036;stroke:#ffffff">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7172"
-         style="stroke:none" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7174"
-         style="fill:none" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7177" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7179" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle7182" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle7184" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       x="335.23718"
-       y="156"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="296.07718"
-         y="156"
-         id="tspan7187">Contribuinte</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="542.07141"
-       y="470.41406">
-      <tspan
-         x="496.1514"
-         y="470.41406"
-         id="tspan7190">Rede Bisq</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="132.44075"
-       y="473">
-      <tspan
-         x="109.92875"
-         y="473"
-         id="tspan7193">Negociante</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan7196">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle7199" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle7201" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           transform="translate(56.326,45.315)"
-           style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start">
-          <tspan
-             sodipodi:role="line"
-             id="tspan7787"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="0">BITCOIN</tspan>
-          <tspan
-             sodipodi:role="line"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="15"
-             id="tspan9250">COLORIDO</tspan>
-          <tspan
-             sodipodi:role="line"
-             style="font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle"
-             x="0"
-             y="30"
-             id="tspan9246">BSQ</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       transform="translate(530.835,259)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-50.448002"
-         y="0"
-         id="tspan7216">Compensação</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       transform="translate(142.835,271)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-51.296001"
-         y="0"
-         id="tspan7219">Melhoramento</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="306.57166"
-       y="583">
-      <tspan
-         x="262.30765"
-         y="583"
-         id="tspan7222">Taxas de Negociação</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_what.svg
+++ b/pt-PT/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg1426"
-   sodipodi:docname="dao_what.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1430">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1428"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.7503671"
-     inkscape:cx="275.03154"
-     inkscape:cy="123.82337"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs1392">
-    <style
-       type="text/css"
-       id="style1385">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1387">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,137 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect1389" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle1394" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle1396" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle1399" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle1401" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         transform="translate(552.211,352.601)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-33.102001"
-           y="0"
-           id="tspan1404">Contribuintes</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         transform="translate(348.835,408.35)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-35.25"
-           y="0"
-           id="tspan1407">Contribuições</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         transform="translate(348.835,296.853)"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-11.934"
-           y="0"
-           id="tspan1410">Taxas</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="129.71001"
-         y="352.60101">
-        <tspan
-           x="109.574"
-           y="352.60101"
-           id="tspan1413">Negociantes</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan1421">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_what.svg
+++ b/pt-PT/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Contribuintes</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Contribuintes</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Taxas</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Negociantes</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_why.svg
+++ b/pt-PT/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg1379"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1383">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1381"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="2.0123153"
-     inkscape:cx="244.37332"
-     inkscape:cy="282.5104"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs1160">
-    <style
-       type="text/css"
-       id="style1153">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1155">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,956 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect1157" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1178" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1180" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1183" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1185" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1188" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1190" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1193" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1195" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1198" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1200" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1203" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1205" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1208" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1210" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1229" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1231" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1234" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1236" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle1239" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle1241" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1244" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1246" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1249" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1251" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1254" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1256" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1259" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1261" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1264" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1266" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1269" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1271" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1274" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1276" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1296" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1298" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1301" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1303" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1306" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1308" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1311" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1313" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1316" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1318" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1321" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1323" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1326" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1328" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle1333" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle1335" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         transform="translate(487.835,511)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-69.587997"
-           y="0"
-           id="tspan1338">Governação Descentralizada</tspan>
-        <tspan
-           x="-69.587997"
-           y="0"
-           id="tspan3213" />
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         transform="translate(173.835,511)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5">
-        <tspan
-           x="-71.117996"
-           y="0"
-           id="tspan1341">Ponto de Falha Centralizado</tspan>
-        <tspan
-           x="-71.117996"
-           y="0"
-           id="tspan3211" />
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         transform="translate(174,166)"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-60.598999"
-           y="0"
-           id="tspan1344">Sem OAD</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         transform="translate(485,166)"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-45.132999"
-           y="0"
-           id="tspan1347">Com OAD</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="328.13129"
-         y="298">
-        <tspan
-           x="295.0293"
-           y="298"
-           id="tspan1350">Contribuintes</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="318.05396"
-         y="351">
-        <tspan
-           x="297.91797"
-           y="351"
-           id="tspan1353">Negociantes</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1356">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1359">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1362">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="162"
-         transform="translate(247.5 320.5)" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1368">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1371">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1374">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/pt-PT/images/DAO/dao_why.svg
+++ b/pt-PT/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Governação Descentralizada</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Ponto de Falha Centralizado</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Sem OAD</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">COM OAD</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Contribuintes</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Negociantes</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/ru/images/DAO/dao_benefits.svg
+++ b/ru/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(490.002 2554.057)">
         <tspan x="0" y="0">Комиссии</tspan>
         <tspan x="0" y="17">·</tspan>
       </text>

--- a/ru/images/DAO/dao_benefits.svg
+++ b/ru/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">Комиссии</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ, эмитированные</tspan>
+        <tspan x="0" y="17">в качестве компенсации</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/ru/images/DAO/dao_benefits.svg
+++ b/ru/images/DAO/dao_benefits.svg
@@ -46,9 +46,9 @@
   </defs>
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
-      <text id="Trading_fees" data-name="Trading
+      <text id="dao_benefits_burn" data-name="Trading
 fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
-      <text id="BSQ_issued_for_compensations" data-name="BSQ issued
+      <text id="dao_benefits_issuance" data-name="BSQ issued
 for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>

--- a/ru/images/DAO/dao_how.svg
+++ b/ru/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">Распределение доходов</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">Принятие решений</tspan>
+    </text>
   </g>
 </svg>

--- a/ru/images/DAO/dao_how.svg
+++ b/ru/images/DAO/dao_how.svg
@@ -79,7 +79,7 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="Revenue-distribution" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="Decision-making" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/ru/images/DAO/dao_intro.svg
+++ b/ru/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">Разработчик</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Сеть Bisq</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">Трейдер</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">BSQ</tspan>
+          <tspan x="-26.028" y="15">(«ЦВЕТНОЙ»</tspan>
+          <tspan x="-23.79" y="30">БИТКОЙН)</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">Компенсация</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">Улучшения</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">Комиссии</tspan>
+    </text>
   </g>
 </svg>

--- a/ru/images/DAO/dao_intro.svg
+++ b/ru/images/DAO/dao_intro.svg
@@ -87,9 +87,9 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="Contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="Bisq_Network" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="Trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
       <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
@@ -97,7 +97,7 @@
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
           <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text id="BSQ_COLORED_BITCOIN" data-name="BSQ
+        <text id="dao_intro_bsq" data-name="BSQ
 COLORED
 BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
@@ -105,8 +105,8 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="Compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="Improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="Trading_Fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/ru/images/DAO/dao_intro.svg
+++ b/ru/images/DAO/dao_intro.svg
@@ -88,10 +88,10 @@
     <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
       <tspan x="-39.16" y="0">Разработчик</tspan>
     </text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(542.835 473)">
       <tspan x="-45.92" y="0">Сеть Bisq</tspan>
     </text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+    <text id="dao_intro_trader" class="cls-6" transform="translate(150.835 473)">
       <tspan x="-22.512" y="0">Трейдер</tspan>
     </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
@@ -105,7 +105,7 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+BITCOIN" class="cls-8" transform="translate(51.326 45.315)">
           <tspan x="-11.418" y="0">BSQ</tspan>
           <tspan x="-26.028" y="15">(«ЦВЕТНОЙ»</tspan>
           <tspan x="-23.79" y="30">БИТКОЙН)</tspan>

--- a/ru/images/DAO/dao_what.svg
+++ b/ru/images/DAO/dao_what.svg
@@ -67,10 +67,10 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="Contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="Contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="Fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="Traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>

--- a/ru/images/DAO/dao_what.svg
+++ b/ru/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">Разработчики</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">Улучшения Bisq</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">Комиссии</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">Трейдеры</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/ru/images/DAO/dao_why.svg
+++ b/ru/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">Децентрализованное управление</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">Централизованная точка отказа</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">Без ДАО</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">С ДАО</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">Разработчики</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">Трейдеры</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/ru/images/DAO/dao_why.svg
+++ b/ru/images/DAO/dao_why.svg
@@ -238,12 +238,12 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="Decentralized_Governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="Centralized_Point_of_Failure" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="Without_DAO" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="With_DAO" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="Contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="Traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
       <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
       <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>

--- a/zh-CN/images/DAO/dao_benefits.svg
+++ b/zh-CN/images/DAO/dao_benefits.svg
@@ -46,7 +46,7 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)">
+fees" class="cls-2" transform="translate(490.002 2554.057)">
         <tspan x="0" y="0">交易手续费</tspan>
         <tspan x="0" y="17">·</tspan>
       </text>

--- a/zh-CN/images/DAO/dao_benefits.svg
+++ b/zh-CN/images/DAO/dao_benefits.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg243"
-   sodipodi:docname="dao_benefits.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata247">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview245"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.3861968"
-     inkscape:cx="518.31288"
-     inkscape:cy="319.39436"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_21" />
-  <defs
-     id="defs221">
-    <style
-       type="text/css"
-       id="style214">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style216">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
       }
@@ -91,89 +40,24 @@
         stroke-width: 0.8px;
       }
     </style>
-    <clipPath
-       id="clip-dao_benefits">
-      <rect
-         width="681"
-         height="681"
-         id="rect218" />
+    <clipPath id="clip-dao_benefits">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_benefits"
-     class="cls-1"
-     clip-path="url(#clip-dao_benefits)">
-    <g
-       id="Group_21"
-       data-name="Group 21"
-       transform="translate(-55.548 -2259.605)">
-      <text
-         id="Trading_fees"
-         data-name="Trading fees"
-         class="cls-2"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="496.00201"
-         y="2554.0569">交易手续费</text>
-      <text
-         id="BSQ_issued_for_compensations"
-         data-name="BSQ issued for compensations"
-         class="cls-2"
-         transform="translate(470.921,2727.626)"
-         style="font-weight:300;font-size:15px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           sodipodi:role="line"
-           id="tspan251"
-           x="0"
-           y="0">BSQ 发放报偿</tspan>
-      </text>
-      <line
-         id="Line_7"
-         data-name="Line 7"
-         class="cls-3"
-         x2="532.346"
-         transform="translate(125.938 2804.709)" />
-      <line
-         id="Line_8"
-         data-name="Line 8"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2702.407)" />
-      <line
-         id="Line_9"
-         data-name="Line 9"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2600.105)" />
-      <line
-         id="Line_10"
-         data-name="Line 10"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2497.802)" />
-      <line
-         id="Line_11"
-         data-name="Line 11"
-         class="cls-4"
-         x2="532.346"
-         transform="translate(125.938 2395.5)" />
-      <path
-         id="Path_11"
-         data-name="Path 11"
-         class="cls-5"
-         d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071"
-         transform="translate(-4877.062 -131.557)" />
-      <path
-         id="Path_10"
-         data-name="Path 10"
-         class="cls-6"
-         d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337"
-         transform="translate(-4876.686 52.277)" />
-      <line
-         id="Line_18"
-         data-name="Line 18"
-         class="cls-7"
-         y2="409.209"
-         transform="translate(392.11 2395.5)" />
+  <g id="dao_benefits" class="cls-1">
+    <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
+      <text id="dao_benefits_burn" data-name="Trading
+fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+      <text id="dao_benefits_issuance" data-name="BSQ issued
+for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+      <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
+      <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
+      <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>
+      <line id="Line_10" data-name="Line 10" class="cls-4" x2="532.346" transform="translate(125.938 2497.802)"/>
+      <line id="Line_11" data-name="Line 11" class="cls-4" x2="532.346" transform="translate(125.938 2395.5)"/>
+      <path id="Path_11" data-name="Path 11" class="cls-5" d="M5003,2921.9c432.112-32.58,532.346-374.071,532.346-374.071" transform="translate(-4877.062 -131.557)"/>
+      <path id="Path_10" data-name="Path 10" class="cls-6" d="M5005.522,2688.165c411.865,0,529.446-140.337,529.446-140.337" transform="translate(-4876.686 52.277)"/>
+      <line id="Line_18" data-name="Line 18" class="cls-7" y2="409.209" transform="translate(392.11 2395.5)"/>
     </g>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_benefits.svg
+++ b/zh-CN/images/DAO/dao_benefits.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_benefits);
@@ -47,9 +46,15 @@
   <g id="dao_benefits" class="cls-1">
     <g id="Group_21" data-name="Group 21" transform="translate(-55.548 -2259.605)">
       <text id="dao_benefits_burn" data-name="Trading
-fees" class="cls-2" transform="translate(510.002 2554.057)"><tspan x="0" y="0">Trading</tspan><tspan x="0" y="17">fees</tspan></text>
+fees" class="cls-2" transform="translate(510.002 2554.057)">
+        <tspan x="0" y="0">交易手续费</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <text id="dao_benefits_issuance" data-name="BSQ issued
-for compensations" class="cls-2" transform="translate(470.921 2727.626)"><tspan x="0" y="0">BSQ issued </tspan><tspan x="0" y="17">for compensations</tspan></text>
+for compensations" class="cls-2" transform="translate(470.921 2727.626)">
+        <tspan x="0" y="0">BSQ 发放报偿</tspan>
+        <tspan x="0" y="17">·</tspan>
+      </text>
       <line id="Line_7" data-name="Line 7" class="cls-3" x2="532.346" transform="translate(125.938 2804.709)"/>
       <line id="Line_8" data-name="Line 8" class="cls-4" x2="532.346" transform="translate(125.938 2702.407)"/>
       <line id="Line_9" data-name="Line 9" class="cls-4" x2="532.346" transform="translate(125.938 2600.105)"/>

--- a/zh-CN/images/DAO/dao_how.svg
+++ b/zh-CN/images/DAO/dao_how.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
@@ -79,7 +78,11 @@
       <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
       <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
-    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)">
+      <tspan x="-74.48" y="0">收益分配</tspan>
+    </text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)">
+      <tspan x="-59.432" y="0">决策</tspan>
+    </text>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_how.svg
+++ b/zh-CN/images/DAO/dao_how.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg413"
-   sodipodi:docname="dao_how.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata417">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview415"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="0.98018913"
-     inkscape:cx="113.91093"
-     inkscape:cy="317.57921"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_how" />
-  <defs
-     id="defs363">
-    <style
-       type="text/css"
-       id="style356">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style358">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_how);
       }
@@ -82,329 +31,55 @@
         font-weight: 300;
       }
     </style>
-    <clipPath
-       id="clip-dao_how">
-      <rect
-         width="681"
-         height="681"
-         id="rect360" />
+    <clipPath id="clip-dao_how">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_how"
-     class="cls-1"
-     clip-path="url(#clip-dao_how)">
-    <g
-       id="Group_45"
-       data-name="Group 45">
-      <path
-         id="Path_43"
-         data-name="Path 43"
-         class="cls-2"
-         d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_44"
-         data-name="Path 44"
-         class="cls-2"
-         d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_45"
-         data-name="Path 45"
-         class="cls-3"
-         d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_46"
-         data-name="Path 46"
-         class="cls-3"
-         d="M9735.255,4330.913l90.5,109.185-22.039-146.313"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_47"
-         data-name="Path 47"
-         class="cls-3"
-         d="M9615.9,4121.825l-41.288,135.522"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_48"
-         data-name="Path 48"
-         class="cls-3"
-         d="M9783.088,4507.913l40.435-70.261-125.217,98.668"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_49"
-         data-name="Path 49"
-         class="cls-3"
-         d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_50"
-         data-name="Path 50"
-         class="cls-3"
-         d="M9954.817,4151.471l-40.414,62.356"
-         transform="translate(-9431 -3969)" />
-      <path
-         id="Path_57"
-         data-name="Path 57"
-         class="cls-3"
-         d="M10012.023,4151.471l-97.62,24.967"
-         transform="translate(-9589.315 -4035.524)" />
-      <path
-         id="Path_51"
-         data-name="Path 51"
-         class="cls-3"
-         d="M9914.4,4151.471l17,37.087"
-         transform="translate(-9606.316 -4044.558)" />
-      <path
-         id="Path_54"
-         data-name="Path 54"
-         class="cls-3"
-         d="M9914.4,4159.471l41-8"
-         transform="translate(-9370.316 -3735.558)" />
-      <path
-         id="Path_55"
-         data-name="Path 55"
-         class="cls-3"
-         d="M9914.406,4164.472l136-13"
-         transform="translate(-9550.316 -3629.559)" />
-      <path
-         id="Path_56"
-         data-name="Path 56"
-         class="cls-3"
-         d="M9914.406,4259.471l201-108"
-         transform="translate(-9790.318 -4010.559)" />
-      <path
-         id="Path_53"
-         data-name="Path 53"
-         class="cls-3"
-         d="M9917.066,4151.471l-2.662,95.9"
-         transform="translate(-9522.316 -3680.373)" />
-      <path
-         id="Path_52"
-         data-name="Path 52"
-         class="cls-3"
-         d="M9914.4,4151.471l221,216"
-         transform="translate(-9591.316 -3943.558)" />
+  <g id="dao_how" class="cls-1">
+    <g id="Group_45" data-name="Group 45">
+      <path id="Path_43" data-name="Path 43" class="cls-2" d="M9739.088,4075.913l117.242,7.749,101.59,71.856c0-.8,50.4,97.716,50.4,97.716,0-.4,7.834,131.414,7.834,131.414l-84.215,107.269-109.076,42.855-127.2,3.385-110.91-77.968-51.74-108.046,22.315-135.072,63.118-92.094Z" transform="translate(-9431 -3969)"/>
+      <path id="Path_44" data-name="Path 44" class="cls-2" d="M9757.911,4108.223l-141.149,15.529,50.773,125.487,87.953-144,157.947,109.979-165.947-35.077,109.313-99.705,56.635,130.935,59.914,181.463,37.052-140.585s-207.7,42.814-208.885,41.352-48.837-115.808-48.837-115.808l-178.561,74.457-44.694,101.876s113.533,68.153,112.074,66.193-70.6-168.069-70.6-168.069l101.192-3.009,245.808-40.248-116.379,88.117-62.9,34.541-71.078-79.4L9641.5,4423.116l54.357,117.9,88.053-33.932-140.5-86.77,182.077,18.117L9930.286,4490l44.906-94.984-151.573,42.017,50.565-72.7-69.286-67.228-134.908-44.86" transform="translate(-9431 -3969)"/>
+      <path id="Path_45" data-name="Path 45" class="cls-3" d="M9876.942,4363.913c-1.117.876-138.5-30.382-138.5-30.382l-101.028,90.722-53.229,37.777" transform="translate(-9431 -3969)"/>
+      <path id="Path_46" data-name="Path 46" class="cls-3" d="M9735.255,4330.913l90.5,109.185-22.039-146.313" transform="translate(-9431 -3969)"/>
+      <path id="Path_47" data-name="Path 47" class="cls-3" d="M9615.9,4121.825l-41.288,135.522" transform="translate(-9431 -3969)"/>
+      <path id="Path_48" data-name="Path 48" class="cls-3" d="M9783.088,4507.913l40.435-70.261-125.217,98.668" transform="translate(-9431 -3969)"/>
+      <path id="Path_49" data-name="Path 49" class="cls-3" d="M9977.32,4392.913c-3.785-1.484-103.7-26.669-103.7-26.669l37.522-156.637,93.526,46.547" transform="translate(-9431 -3969)"/>
+      <path id="Path_50" data-name="Path 50" class="cls-3" d="M9954.817,4151.471l-40.414,62.356" transform="translate(-9431 -3969)"/>
+      <path id="Path_57" data-name="Path 57" class="cls-3" d="M10012.023,4151.471l-97.62,24.967" transform="translate(-9589.315 -4035.524)"/>
+      <path id="Path_51" data-name="Path 51" class="cls-3" d="M9914.4,4151.471l17,37.087" transform="translate(-9606.316 -4044.558)"/>
+      <path id="Path_54" data-name="Path 54" class="cls-3" d="M9914.4,4159.471l41-8" transform="translate(-9370.316 -3735.558)"/>
+      <path id="Path_55" data-name="Path 55" class="cls-3" d="M9914.406,4164.472l136-13" transform="translate(-9550.316 -3629.559)"/>
+      <path id="Path_56" data-name="Path 56" class="cls-3" d="M9914.406,4259.471l201-108" transform="translate(-9790.318 -4010.559)"/>
+      <path id="Path_53" data-name="Path 53" class="cls-3" d="M9917.066,4151.471l-2.662,95.9" transform="translate(-9522.316 -3680.373)"/>
+      <path id="Path_52" data-name="Path 52" class="cls-3" d="M9914.4,4151.471l221,216" transform="translate(-9591.316 -3943.558)"/>
     </g>
-    <g
-       id="Group_46"
-       data-name="Group 46">
-      <circle
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 95)" />
-      <circle
-         id="Ellipse_60"
-         data-name="Ellipse 60"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(413.175 103)" />
-      <circle
-         id="Ellipse_61"
-         data-name="Ellipse 61"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(313.175 129)" />
-      <circle
-         id="Ellipse_82"
-         data-name="Ellipse 82"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(306.175 201)" />
-      <circle
-         id="Ellipse_62"
-         data-name="Ellipse 62"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(175.175 144)" />
-      <circle
-         id="Ellipse_63"
-         data-name="Ellipse 63"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(112.175 237)" />
-      <circle
-         id="Ellipse_64"
-         data-name="Ellipse 64"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(132.175 276)" />
-      <circle
-         id="Ellipse_65"
-         data-name="Ellipse 65"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(226.175 269)" />
-      <circle
-         id="Ellipse_66"
-         data-name="Ellipse 66"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(91.175 371)" />
-      <circle
-         id="Ellipse_67"
-         data-name="Ellipse 67"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(144.175 481)" />
-      <circle
-         id="Ellipse_68"
-         data-name="Ellipse 68"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(199.175 440)" />
-      <circle
-         id="Ellipse_69"
-         data-name="Ellipse 69"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(254.175 557)" />
-      <circle
-         id="Ellipse_70"
-         data-name="Ellipse 70"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(340.175 527)" />
-      <circle
-         id="Ellipse_71"
-         data-name="Ellipse 71"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(380.175 553)" />
-      <circle
-         id="Ellipse_72"
-         data-name="Ellipse 72"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(382.175 457)" />
-      <circle
-         id="Ellipse_73"
-         data-name="Ellipse 73"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(296.175 350)" />
-      <circle
-         id="Ellipse_74"
-         data-name="Ellipse 74"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(361.175 314)" />
-      <circle
-         id="Ellipse_75"
-         data-name="Ellipse 75"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(431.175 383)" />
-      <circle
-         id="Ellipse_76"
-         data-name="Ellipse 76"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(488.175 510)" />
-      <circle
-         id="Ellipse_77"
-         data-name="Ellipse 77"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(532.175 412)" />
-      <circle
-         id="Ellipse_78"
-         data-name="Ellipse 78"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(573.175 404)" />
-      <circle
-         id="Ellipse_79"
-         data-name="Ellipse 79"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(565.175 273)" />
-      <circle
-         id="Ellipse_80"
-         data-name="Ellipse 80"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(469.175 232)" />
-      <circle
-         id="Ellipse_81"
-         data-name="Ellipse 81"
-         class="cls-4"
-         cx="11.912"
-         cy="11.912"
-         r="11.912"
-         transform="translate(512.175 171)" />
+    <g id="Group_46" data-name="Group 46">
+      <circle id="Ellipse_1" data-name="Ellipse 1" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 95)"/>
+      <circle id="Ellipse_60" data-name="Ellipse 60" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(413.175 103)"/>
+      <circle id="Ellipse_61" data-name="Ellipse 61" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(313.175 129)"/>
+      <circle id="Ellipse_82" data-name="Ellipse 82" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(306.175 201)"/>
+      <circle id="Ellipse_62" data-name="Ellipse 62" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(175.175 144)"/>
+      <circle id="Ellipse_63" data-name="Ellipse 63" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(112.175 237)"/>
+      <circle id="Ellipse_64" data-name="Ellipse 64" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(132.175 276)"/>
+      <circle id="Ellipse_65" data-name="Ellipse 65" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(226.175 269)"/>
+      <circle id="Ellipse_66" data-name="Ellipse 66" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(91.175 371)"/>
+      <circle id="Ellipse_67" data-name="Ellipse 67" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(144.175 481)"/>
+      <circle id="Ellipse_68" data-name="Ellipse 68" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(199.175 440)"/>
+      <circle id="Ellipse_69" data-name="Ellipse 69" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(254.175 557)"/>
+      <circle id="Ellipse_70" data-name="Ellipse 70" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(340.175 527)"/>
+      <circle id="Ellipse_71" data-name="Ellipse 71" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(380.175 553)"/>
+      <circle id="Ellipse_72" data-name="Ellipse 72" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(382.175 457)"/>
+      <circle id="Ellipse_73" data-name="Ellipse 73" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(296.175 350)"/>
+      <circle id="Ellipse_74" data-name="Ellipse 74" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(361.175 314)"/>
+      <circle id="Ellipse_75" data-name="Ellipse 75" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(431.175 383)"/>
+      <circle id="Ellipse_76" data-name="Ellipse 76" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(488.175 510)"/>
+      <circle id="Ellipse_77" data-name="Ellipse 77" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(532.175 412)"/>
+      <circle id="Ellipse_78" data-name="Ellipse 78" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(573.175 404)"/>
+      <circle id="Ellipse_79" data-name="Ellipse 79" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(565.175 273)"/>
+      <circle id="Ellipse_80" data-name="Ellipse 80" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(469.175 232)"/>
+      <circle id="Ellipse_81" data-name="Ellipse 81" class="cls-4" cx="11.912" cy="11.912" r="11.912" transform="translate(512.175 171)"/>
     </g>
-    <text
-       id="Revenue-distribution"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="386.52701"
-       y="70.601997">
-      <tspan
-         x="312.047"
-         y="70.601997"
-         id="tspan406">收益分配</tspan>
-    </text>
-    <text
-       id="Decision-making"
-       class="cls-5"
-       style="font-weight:300;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="387.44699"
-       y="617.60199">
-      <tspan
-         x="328.01501"
-         y="617.60199"
-         id="tspan409">决策</tspan>
-    </text>
+    <text id="dao_how_revenue" class="cls-5" transform="translate(343.875 70.602)"><tspan x="-74.48" y="0">Revenue-distribution</tspan></text>
+    <text id="dao_how_decisions" class="cls-5" transform="translate(343.875 617.602)"><tspan x="-59.432" y="0">Decision-making</tspan></text>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_intro.svg
+++ b/zh-CN/images/DAO/dao_intro.svg
@@ -85,10 +85,10 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(355.835 156)">
       <tspan x="-39.16" y="0">贡献者</tspan>
     </text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(547.835 473)">
       <tspan x="-45.92" y="0">Bisq 网络</tspan>
     </text>
     <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
@@ -115,10 +115,10 @@ BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(560.835 259)">
       <tspan x="-50.448" y="0">报酬</tspan>
     </text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(172.835 271)">
       <tspan x="-51.296" y="0">改进</tspan>
     </text>
     <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">

--- a/zh-CN/images/DAO/dao_intro.svg
+++ b/zh-CN/images/DAO/dao_intro.svg
@@ -1,8 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
@@ -87,11 +85,19 @@
       <circle class="cls-10" cx="65" cy="65" r="65"/>
       <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
-    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
-    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)">
+      <tspan x="-39.16" y="0">贡献者</tspan>
+    </text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)">
+      <tspan x="-45.92" y="0">Bisq 网络</tspan>
+    </text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)">
+      <tspan x="-22.512" y="0">交易商</tspan>
+    </text>
     <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
-      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)">
+        <tspan x="-70.482" y="0">₿</tspan>
+      </text>
       <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
         <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
           <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
@@ -99,14 +105,24 @@
         </g>
         <text id="dao_intro_bsq" data-name="BSQ
 COLORED
-BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)">
+          <tspan x="-11.418" y="0">基于</tspan>
+          <tspan x="-26.028" y="15">BTC</tspan>
+          <tspan x="-23.79" y="30">的 BSQ</tspan>
+        </text>
       </g>
     </g>
     <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
     <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
     <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
-    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
-    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
-    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)">
+      <tspan x="-50.448" y="0">报酬</tspan>
+    </text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)">
+      <tspan x="-51.296" y="0">改进</tspan>
+    </text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)">
+      <tspan x="-44.264" y="0">交易手续费</tspan>
+    </text>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_intro.svg
+++ b/zh-CN/images/DAO/dao_intro.svg
@@ -1,59 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="681"
-   viewBox="0 0 681 681"
-   version="1.1"
-   id="svg607"
-   sodipodi:docname="dao_intro.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata611">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview609"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.9603783"
-     inkscape:cx="251.83919"
-     inkscape:cy="439.18505"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="dao_intro" />
-  <defs
-     id="defs545">
-    <style
-       type="text/css"
-       id="style536">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style538">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="681" viewBox="0 0 681 681">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1, .cls-6, .cls-7 {
         fill: #fff;
       }
@@ -111,242 +61,52 @@
         fill: rgba(255,255,255,0.5);
       }
     </style>
-    <clipPath
-       id="clip-path">
-      <path
-         id="Subtraction_1"
-         data-name="Subtraction 1"
-         class="cls-1"
-         d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z"
-         transform="translate(9503 1960)" />
+    <clipPath id="clip-path">
+      <path id="Subtraction_1" data-name="Subtraction 1" class="cls-1" d="M-8894-1335h-537v-495h537v495Zm-322.167-65v37h119v-37ZM-9360.9-1712.186l-12.655,34.77,29.129,10.6,12.655-34.769-29.129-10.6Zm393.521-16.587h0l-23.212,15.657,20.688,30.674,23.212-15.657-20.688-30.674Z" transform="translate(9503 1960)"/>
     </clipPath>
-    <clipPath
-       id="clip-dao_intro">
-      <rect
-         width="681"
-         height="681"
-         id="rect542" />
+    <clipPath id="clip-dao_intro">
+      <rect width="681" height="681"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_intro"
-     class="cls-2"
-     clip-path="url(#clip-dao_intro)">
-    <g
-       id="Mask_Group_2"
-       data-name="Mask Group 2"
-       class="cls-3"
-       clip-path="url(#clip-path)">
-      <g
-         id="Path_22"
-         data-name="Path 22"
-         class="cls-4"
-         transform="translate(125.835 141)">
-        <path
-           class="cls-10"
-           d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"
-           id="path547" />
-        <path
-           class="cls-11"
-           d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"
-           id="path549" />
+  <g id="dao_intro" class="cls-2">
+    <g id="Mask_Group_2" data-name="Mask Group 2" class="cls-3">
+      <g id="Path_22" data-name="Path 22" class="cls-4" transform="translate(125.835 141)">
+        <path class="cls-10" d="M220,0C341.5,0,440,98.5,440,220S341.5,440,220,440,0,341.5,0,220,98.5,0,220,0Z"/>
+        <path class="cls-11" d="M 220 1 C 205.1405029296875 1 190.2906036376953 2.4969482421875 175.8628234863281 5.4493408203125 C 161.8022155761719 8.326568603515625 147.9717712402344 12.61972045898438 134.755615234375 18.209716796875 C 121.7792358398438 23.69827270507812 109.2633361816406 30.49166870117188 97.55572509765625 38.40115356445312 C 85.95904541015625 46.2357177734375 75.05404663085938 55.233154296875 65.14361572265625 65.14361572265625 C 55.233154296875 75.05404663085938 46.2357177734375 85.95904541015625 38.40115356445312 97.55572509765625 C 30.49166870117188 109.2633361816406 23.69827270507812 121.7792358398438 18.209716796875 134.755615234375 C 12.61972045898438 147.9717712402344 8.326568603515625 161.8022155761719 5.4493408203125 175.8628234863281 C 2.4969482421875 190.2906036376953 1 205.1405029296875 1 220 C 1 234.8594970703125 2.4969482421875 249.7093963623047 5.4493408203125 264.1371459960938 C 8.326568603515625 278.1977844238281 12.61972045898438 292.0282287597656 18.209716796875 305.244384765625 C 23.69827270507812 318.2207641601562 30.49166870117188 330.7366638183594 38.40115356445312 342.4442749023438 C 46.2357177734375 354.0409545898438 55.233154296875 364.9459533691406 65.14361572265625 374.8563842773438 C 75.05404663085938 384.766845703125 85.95904541015625 393.7642822265625 97.55572509765625 401.5988464355469 C 109.2633361816406 409.5083312988281 121.7792358398438 416.3017272949219 134.755615234375 421.790283203125 C 147.9717712402344 427.3802795410156 161.8022155761719 431.6734313964844 175.8628234863281 434.5506591796875 C 190.2906036376953 437.5030517578125 205.1405029296875 439 220 439 C 234.8594970703125 439 249.7093963623047 437.5030517578125 264.1371459960938 434.5506591796875 C 278.1977844238281 431.6734313964844 292.0282287597656 427.3802795410156 305.244384765625 421.790283203125 C 318.2207641601562 416.3017272949219 330.7366638183594 409.5083312988281 342.4442749023438 401.5988464355469 C 354.0409545898438 393.7642822265625 364.9459533691406 384.766845703125 374.8563842773438 374.8563842773438 C 384.766845703125 364.9459533691406 393.7642822265625 354.0409545898438 401.5988464355469 342.4442749023438 C 409.5083312988281 330.7366638183594 416.3017272949219 318.2207641601562 421.790283203125 305.244384765625 C 427.3802795410156 292.0282287597656 431.6734313964844 278.1977844238281 434.5506591796875 264.1371459960938 C 437.5030517578125 249.7093963623047 439 234.8594970703125 439 220 C 439 205.1405029296875 437.5030517578125 190.2906036376953 434.5506591796875 175.8628234863281 C 431.6734313964844 161.8022155761719 427.3802795410156 147.9717712402344 421.790283203125 134.755615234375 C 416.3017272949219 121.7792358398438 409.5083312988281 109.2633361816406 401.5988464355469 97.55572509765625 C 393.7642822265625 85.95904541015625 384.766845703125 75.05404663085938 374.8563842773438 65.14361572265625 C 364.9459533691406 55.233154296875 354.0409545898438 46.2357177734375 342.4442749023438 38.40115356445312 C 330.7366638183594 30.49166870117188 318.2207641601562 23.69827270507812 305.244384765625 18.209716796875 C 292.0282287597656 12.61972045898438 278.1977844238281 8.326568603515625 264.1371459960938 5.4493408203125 C 249.7093963623047 2.4969482421875 234.8594970703125 1 220 1 M 220 0 C 341.5026245117188 0 440 98.49737548828125 440 220 C 440 341.5026245117188 341.5026245117188 440 220 440 C 98.49737548828125 440 0 341.5026245117188 0 220 C 0 98.49737548828125 98.49737548828125 0 220 0 Z"/>
       </g>
     </g>
-    <g
-       id="Ellipse_1"
-       data-name="Ellipse 1"
-       class="cls-5"
-       transform="translate(280.835 85)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle553" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle555" />
+    <g id="Ellipse_1" data-name="Ellipse 1" class="cls-5" transform="translate(280.835 85)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_2"
-       data-name="Ellipse 2"
-       class="cls-5"
-       transform="translate(470.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle558" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle560" />
+    <g id="Ellipse_2" data-name="Ellipse 2" class="cls-5" transform="translate(470.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <g
-       id="Ellipse_3"
-       data-name="Ellipse 3"
-       class="cls-5"
-       transform="translate(90.835 401)">
-      <circle
-         class="cls-10"
-         cx="65"
-         cy="65"
-         r="65"
-         id="circle563" />
-      <circle
-         class="cls-12"
-         cx="65"
-         cy="65"
-         r="64.5"
-         id="circle565" />
+    <g id="Ellipse_3" data-name="Ellipse 3" class="cls-5" transform="translate(90.835 401)">
+      <circle class="cls-10" cx="65" cy="65" r="65"/>
+      <circle class="cls-12" cx="65" cy="65" r="64.5"/>
     </g>
-    <text
-       id="Contributor"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="360.94699"
-       y="156.056">
-      <tspan
-         x="321.78699"
-         y="156.056"
-         id="tspan568">贡献者</tspan>
-    </text>
-    <text
-       id="Bisq_Network"
-       data-name="Bisq Network"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="545.80585"
-       y="473">
-      <tspan
-         x="499.88583"
-         y="473"
-         id="tspan571">Bisq 网络</tspan>
-    </text>
-    <text
-       id="Trader"
-       class="cls-6"
-       transform="translate(155.835,473)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-22.511999"
-         y="0"
-         id="tspan574">交易商</tspan>
-    </text>
-    <g
-       id="Group_25"
-       data-name="Group 25"
-       transform="translate(-737.165 -91)">
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-7"
-         transform="translate(1076.776 523.439)">
-        <tspan
-           x="-70.482"
-           y="0"
-           id="tspan577">₿</tspan>
-      </text>
-      <g
-         id="Group_3"
-         data-name="Group 3"
-         transform="translate(1068.674 456.685)">
-        <g
-           id="Ellipse_14"
-           data-name="Ellipse 14"
-           class="cls-5"
-           transform="translate(7.326 7.315)">
-          <circle
-             class="cls-10"
-             cx="48.775"
-             cy="48.775"
-             r="48.775"
-             id="circle580" />
-          <circle
-             class="cls-12"
-             cx="48.775"
-             cy="48.775"
-             r="48.275"
-             id="circle582" />
+    <text id="dao_intro_contributor" class="cls-6" transform="translate(345.835 156)"><tspan x="-39.16" y="0">Contributor</tspan></text>
+    <text id="dao_intro_bisq" data-name="Bisq Network" class="cls-6" transform="translate(537.835 473)"><tspan x="-45.92" y="0">Bisq Network</tspan></text>
+    <text id="dao_intro_trader" class="cls-6" transform="translate(155.835 473)"><tspan x="-22.512" y="0">Trader</tspan></text>
+    <g id="Group_25" data-name="Group 25" transform="translate(-737.165 -91)">
+      <text id="_" data-name="₿" class="cls-7" transform="translate(1076.776 523.439)"><tspan x="-70.482" y="0">₿</tspan></text>
+      <g id="Group_3" data-name="Group 3" transform="translate(1068.674 456.685)">
+        <g id="Ellipse_14" data-name="Ellipse 14" class="cls-5" transform="translate(7.326 7.315)">
+          <circle class="cls-10" cx="48.775" cy="48.775" r="48.775"/>
+          <circle class="cls-12" cx="48.775" cy="48.775" r="48.275"/>
         </g>
-        <text
-           id="BSQ_COLORED_BITCOIN"
-           data-name="BSQ COLORED BITCOIN"
-           class="cls-8"
-           x="56.168056"
-           y="52.093159"
-           style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif">
-          <tspan
-             sodipodi:role="line"
-             id="tspan629"
-             x="56.168056"
-             y="52.093159"
-             style="text-align:center;text-anchor:middle">基于 BTC</tspan>
-          <tspan
-             sodipodi:role="line"
-             id="tspan631"
-             x="56.168056"
-             y="68.535973"
-             style="text-align:center;text-anchor:middle">的 BSQ</tspan>
-        </text>
+        <text id="dao_intro_bsq" data-name="BSQ
+COLORED
+BITCOIN" class="cls-8" transform="translate(56.326 45.315)"><tspan x="-11.418" y="0">BSQ</tspan><tspan x="-26.028" y="15">COLORED</tspan><tspan x="-23.79" y="30">BITCOIN</tspan></text>
       </g>
     </g>
-    <path
-       id="Path_3"
-       data-name="Path 3"
-       class="cls-9"
-       d="M4596.828,610.088h18.285v17.163"
-       transform="translate(-4117.165 -91)" />
-    <path
-       id="Path_4"
-       data-name="Path 4"
-       class="cls-9"
-       d="M4596.828,610.088h18.382v18.387"
-       transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)" />
-    <path
-       id="Path_5"
-       data-name="Path 5"
-       class="cls-9"
-       d="M4596.828,610.088h16.315V625.4"
-       transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)" />
-    <text
-       id="Compensation"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="570.83502"
-       y="259">
-      <tspan
-         x="520.38696"
-         y="259"
-         id="tspan597">报酬</tspan>
-    </text>
-    <text
-       id="Improvements"
-       class="cls-6"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-       x="182.83501"
-       y="271">
-      <tspan
-         x="131.539"
-         y="271"
-         id="tspan600">改进</tspan>
-    </text>
-    <text
-       id="Trading_Fees"
-       data-name="Trading Fees"
-       class="cls-6"
-       transform="translate(345.835,583)"
-       style="font-weight:200;font-size:16px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-      <tspan
-         x="-44.264"
-         y="0"
-         id="tspan603">交易手续费</tspan>
-    </text>
+    <path id="Path_3" data-name="Path 3" class="cls-9" d="M4596.828,610.088h18.285v17.163" transform="translate(-4117.165 -91)"/>
+    <path id="Path_4" data-name="Path 4" class="cls-9" d="M4596.828,610.088h18.382v18.387" transform="matrix(-0.469, -0.883, 0.883, -0.469, 2038.532, 4512.624)"/>
+    <path id="Path_5" data-name="Path 5" class="cls-9" d="M4596.828,610.088h16.315V625.4" transform="matrix(-0.469, 0.883, -0.883, -0.469, 2835.459, -3381.042)"/>
+    <text id="dao_intro_compensation" class="cls-6" transform="translate(530.835 259)"><tspan x="-50.448" y="0">Compensation</tspan></text>
+    <text id="dao_intro_improvements" class="cls-6" transform="translate(142.835 271)"><tspan x="-51.296" y="0">Improvements</tspan></text>
+    <text id="dao_intro_fees" data-name="Trading Fees" class="cls-6" transform="translate(345.835 583)"><tspan x="-44.264" y="0">Trading Fees</tspan></text>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_what.svg
+++ b/zh-CN/images/DAO/dao_what.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
   <defs>
-
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
@@ -67,17 +64,27 @@
         <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
         <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
-      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
-      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)">
+        <tspan x="-33.102" y="0">贡献者</tspan>
+      </text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)">
+        <tspan x="-35.25" y="0">贡献</tspan>
+      </text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)">
+        <tspan x="-11.934" y="0">手续费</tspan>
+      </text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)">
+        <tspan x="-20.136" y="0">交易商</tspan>
+      </text>
       <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
         <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
         <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
         <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
         <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)">
+        <tspan x="-27.63" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_what.svg
+++ b/zh-CN/images/DAO/dao_what.svg
@@ -1,59 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="681"
-   height="264"
-   viewBox="0 0 681 264"
-   version="1.1"
-   id="svg761"
-   sodipodi:docname="dao_what.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata765">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview763"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.7503671"
-     inkscape:cx="275.85992"
-     inkscape:cy="60.687327"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_44" />
-  <defs
-     id="defs727">
-    <style
-       type="text/css"
-       id="style720">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style722">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="681" height="264" viewBox="0 0 681 264">
+  <defs>
+
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_what);
       }
@@ -102,140 +53,31 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_what">
-      <rect
-         width="681"
-         height="264"
-         id="rect724" />
+    <clipPath id="clip-dao_what">
+      <rect width="681" height="264"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_what"
-     class="cls-1"
-     clip-path="url(#clip-dao_what)">
-    <g
-       id="Group_44"
-       data-name="Group 44"
-       transform="translate(-8.835 -215)">
-      <g
-         id="Ellipse_1"
-         data-name="Ellipse 1"
-         class="cls-2"
-         transform="translate(434.01 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle729" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle731" />
+  <g id="dao_what" class="cls-1">
+    <g id="Group_44" data-name="Group 44" transform="translate(-8.835 -215)">
+      <g id="Ellipse_1" data-name="Ellipse 1" class="cls-2" transform="translate(434.01 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <g
-         id="Ellipse_59"
-         data-name="Ellipse 59"
-         class="cls-2"
-         transform="translate(24.835 227)">
-        <circle
-           class="cls-8"
-           cx="119.912"
-           cy="119.912"
-           r="119.912"
-           id="circle734" />
-        <circle
-           class="cls-9"
-           cx="119.912"
-           cy="119.912"
-           r="119.412"
-           id="circle736" />
+      <g id="Ellipse_59" data-name="Ellipse 59" class="cls-2" transform="translate(24.835 227)">
+        <circle class="cls-8" cx="119.912" cy="119.912" r="119.912"/>
+        <circle class="cls-9" cx="119.912" cy="119.912" r="119.412"/>
       </g>
-      <text
-         id="Contributors"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="568.98798"
-         y="351.45401">
-        <tspan
-           x="535.88599"
-           y="351.45401"
-           id="tspan739">贡献者</tspan>
-      </text>
-      <text
-         id="Contributions"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="375.58655"
-         y="408.35001">
-        <tspan
-           x="340.33655"
-           y="408.35001"
-           id="tspan742">贡献</tspan>
-      </text>
-      <text
-         id="Fees"
-         class="cls-4"
-         style="font-style:italic;font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="346.31253"
-         y="296.853">
-        <tspan
-           x="334.37854"
-           y="296.853"
-           id="tspan745">手续费</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-3"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="147.033"
-         y="351.448">
-        <tspan
-           x="126.897"
-           y="351.448"
-           id="tspan748">交易商</tspan>
-      </text>
-      <g
-         id="Group_43"
-         data-name="Group 43"
-         transform="translate(236.433 304.838)">
-        <path
-           id="Path_4"
-           data-name="Path 4"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(221.626 0) rotate(45)" />
-        <path
-           id="Path_41"
-           data-name="Path 41"
-           class="cls-5"
-           d="M0,0H6.279V6.279"
-           transform="translate(4.439 84.614) rotate(-135)" />
-        <line
-           id="Line_46"
-           data-name="Line 46"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(0.483 4.454)" />
-        <line
-           id="Line_47"
-           data-name="Line 47"
-           class="cls-6"
-           x2="226.151"
-           transform="translate(226.634 80.16) rotate(180)" />
+      <text id="dao_why_contributors" class="cls-3" transform="translate(552.211 352.601)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_what_contributions" class="cls-4" transform="translate(348.835 408.35)"><tspan x="-35.25" y="0">Contributions</tspan></text>
+      <text id="dao_what_fees" class="cls-4" transform="translate(348.835 296.853)"><tspan x="-11.934" y="0">Fees</tspan></text>
+      <text id="dao_what_traders" class="cls-3" transform="translate(143.71 352.601)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <g id="Group_43" data-name="Group 43" transform="translate(236.433 304.838)">
+        <path id="Path_4" data-name="Path 4" class="cls-5" d="M0,0H6.279V6.279" transform="translate(221.626 0) rotate(45)"/>
+        <path id="Path_41" data-name="Path 41" class="cls-5" d="M0,0H6.279V6.279" transform="translate(4.439 84.614) rotate(-135)"/>
+        <line id="Line_46" data-name="Line 46" class="cls-6" x2="226.151" transform="translate(0.483 4.454)"/>
+        <line id="Line_47" data-name="Line 47" class="cls-6" x2="226.151" transform="translate(226.634 80.16) rotate(180)"/>
       </g>
-      <text
-         id="BSQ"
-         class="cls-7"
-         transform="translate(348.835 357)">
-        <tspan
-           x="-27.63"
-           y="0"
-           id="tspan756">BSQ</tspan>
-      </text>
+      <text id="BSQ" class="cls-7" transform="translate(348.835 357)"><tspan x="-27.63" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_why.svg
+++ b/zh-CN/images/DAO/dao_why.svg
@@ -1,7 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
   <defs>
     <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-
     <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
@@ -238,21 +237,45 @@
         <circle class="cls-13" cx="47" cy="47" r="47"/>
         <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
-      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
-      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
-      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
-      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
-      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
-      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
-      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)">
+        <tspan x="-69.588" y="0">去中心化的表决</tspan>
+      </text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)">
+        <tspan x="-71.118" y="0">中心化的坏处</tspan>
+      </text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)">
+        <tspan x="-60.599" y="0">不使用 DAO</tspan>
+      </text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)">
+        <tspan x="-45.133" y="0">使用 DAO</tspan>
+      </text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)">
+        <tspan x="-33.102" y="0">贡献者</tspan>
+      </text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)">
+        <tspan x="-20.136" y="0">交易商</tspan>
+      </text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)">
+        <tspan x="-2.894" y="0">₿</tspan>
+      </text>
       <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
       <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
       <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
-      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
-      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)">
+        <tspan x="-7.528" y="0">BSQ</tspan>
+      </text>
     </g>
   </g>
 </svg>

--- a/zh-CN/images/DAO/dao_why.svg
+++ b/zh-CN/images/DAO/dao_why.svg
@@ -1,59 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="610"
-   height="406"
-   viewBox="0 0 610 406"
-   version="1.1"
-   id="svg1265"
-   sodipodi:docname="dao_why.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata1269">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1012"
-     id="namedview1267"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="1.9540984"
-     inkscape:cx="335.73243"
-     inkscape:cy="200.614"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Group_42" />
-  <defs
-     id="defs1046">
-    <style
-       type="text/css"
-       id="style1039">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
-    <style
-       id="style1041">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="610" height="406" viewBox="0 0 610 406">
+  <defs>
+    <style type="text/css">@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i');</style>
+
+    <style>
       .cls-1 {
         clip-path: url(#clip-dao_why);
       }
@@ -127,954 +76,183 @@
         stroke: none;
       }
     </style>
-    <clipPath
-       id="clip-dao_why">
-      <rect
-         width="610"
-         height="406"
-         id="rect1043" />
+    <clipPath id="clip-dao_why">
+      <rect width="610" height="406"/>
     </clipPath>
   </defs>
-  <g
-     id="dao_why"
-     class="cls-1"
-     clip-path="url(#clip-dao_why)">
-    <g
-       id="Group_42"
-       data-name="Group 42"
-       transform="translate(-38.5 -131)">
-      <g
-         id="Group_37"
-         data-name="Group 37"
-         transform="translate(266 77)">
-        <line
-           id="Line_25"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <line
-           id="Line_27"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-2"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-3"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-4"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-2"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-5"
-           data-name="Line 27"
-           class="cls-2"
-           y2="56"
-           transform="translate(256.5 258.5)" />
-        <path
-           id="Path_40"
-           data-name="Path 40"
-           class="cls-2"
-           d="M-1,0,0,56"
-           transform="translate(191.5 258.5)" />
-        <line
-           id="Line_27-6"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-7"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-8"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-9"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-2"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+  <g id="dao_why" class="cls-1">
+    <g id="Group_42" data-name="Group 42" transform="translate(-38.5 -131)">
+      <g id="Group_37" data-name="Group 37" transform="translate(266 77)">
+        <line id="Line_25" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <line id="Line_27" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-2" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-3" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-4" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-2" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-5" data-name="Line 27" class="cls-2" y2="56" transform="translate(256.5 258.5)"/>
+        <path id="Path_40" data-name="Path 40" class="cls-2" d="M-1,0,0,56" transform="translate(191.5 258.5)"/>
+        <line id="Line_27-6" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-7" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-8" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-9" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-2" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_46"
-         data-name="Ellipse 46"
-         class="cls-3"
-         transform="translate(408.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1064" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1066" />
+      <g id="Ellipse_46" data-name="Ellipse 46" class="cls-3" transform="translate(408.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_47"
-         data-name="Ellipse 47"
-         class="cls-3"
-         transform="translate(408.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1069" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1071" />
+      <g id="Ellipse_47" data-name="Ellipse 47" class="cls-3" transform="translate(408.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_48"
-         data-name="Ellipse 48"
-         class="cls-3"
-         transform="translate(501.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1074" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1076" />
+      <g id="Ellipse_48" data-name="Ellipse 48" class="cls-3" transform="translate(501.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_40"
-         data-name="Ellipse 40"
-         class="cls-3"
-         transform="translate(470.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1079" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1081" />
+      <g id="Ellipse_40" data-name="Ellipse 40" class="cls-3" transform="translate(470.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_41"
-         data-name="Ellipse 41"
-         class="cls-3"
-         transform="translate(572.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1084" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1086" />
+      <g id="Ellipse_41" data-name="Ellipse 41" class="cls-3" transform="translate(572.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_42"
-         data-name="Ellipse 42"
-         class="cls-3"
-         transform="translate(572.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1089" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1091" />
+      <g id="Ellipse_42" data-name="Ellipse 42" class="cls-3" transform="translate(572.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_43"
-         data-name="Ellipse 43"
-         class="cls-3"
-         transform="translate(510.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1094" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1096" />
+      <g id="Ellipse_43" data-name="Ellipse 43" class="cls-3" transform="translate(510.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Group_36"
-         data-name="Group 36"
-         transform="translate(-48 77)">
-        <line
-           id="Line_25-3"
-           data-name="Line 25"
-           class="cls-2"
-           x1="44"
-           y2="37"
-           transform="translate(139.5 246.5)" />
-        <path
-           id="Path_39"
-           data-name="Path 39"
-           class="cls-2"
-           d="M14.365,0-.519,51.224"
-           transform="translate(196.165 264.813)" />
-        <line
-           id="Line_27-10"
-           data-name="Line 27"
-           class="cls-2"
-           x2="41.665"
-           y2="24"
-           transform="translate(140.5 296.5)" />
-        <line
-           id="Line_27-11"
-           data-name="Line 27"
-           class="cls-2"
-           y1="24"
-           x2="40.665"
-           transform="translate(141.5 332.5)" />
-        <line
-           id="Line_27-12"
-           data-name="Line 27"
-           class="cls-2"
-           x2="72"
-           y2="22"
-           transform="translate(140.5 365.5)" />
-        <line
-           id="Line_27-13"
-           data-name="Line 27"
-           class="cls-2"
-           x2="20"
-           y2="45"
-           transform="translate(197.5 336.5)" />
-        <line
-           id="Line_20-3"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(130.5 302.512)" />
-        <line
-           id="Line_25-4"
-           data-name="Line 25"
-           class="cls-2"
-           x2="48.51"
-           y2="40"
-           transform="translate(260.5 243.5)" />
-        <line
-           id="Line_27-14"
-           data-name="Line 27"
-           class="cls-2"
-           x2="15.303"
-           y2="50.687"
-           transform="translate(237.197 264.813)" />
-        <line
-           id="Line_27-15"
-           data-name="Line 27"
-           class="cls-2"
-           x1="41.665"
-           y2="24"
-           transform="translate(266.338 296.5)" />
-        <line
-           id="Line_27-16"
-           data-name="Line 27"
-           class="cls-2"
-           x1="40.665"
-           y1="24"
-           transform="translate(266.322 332.5)" />
-        <line
-           id="Line_27-17"
-           data-name="Line 27"
-           class="cls-2"
-           x1="72"
-           y2="22"
-           transform="translate(235.676 365.5)" />
-        <line
-           id="Line_27-18"
-           data-name="Line 27"
-           class="cls-2"
-           x1="20"
-           y2="45"
-           transform="translate(230.131 336.5)" />
-        <line
-           id="Line_20-4"
-           data-name="Line 20"
-           class="cls-2"
-           y2="44.976"
-           transform="translate(318.49 302.512)" />
-        <line
-           id="Line_28-2"
-           data-name="Line 28"
-           class="cls-2"
-           x1="42"
-           transform="translate(203.5 324.5)" />
+      <g id="Group_36" data-name="Group 36" transform="translate(-48 77)">
+        <line id="Line_25-3" data-name="Line 25" class="cls-2" x1="44" y2="37" transform="translate(139.5 246.5)"/>
+        <path id="Path_39" data-name="Path 39" class="cls-2" d="M14.365,0-.519,51.224" transform="translate(196.165 264.813)"/>
+        <line id="Line_27-10" data-name="Line 27" class="cls-2" x2="41.665" y2="24" transform="translate(140.5 296.5)"/>
+        <line id="Line_27-11" data-name="Line 27" class="cls-2" y1="24" x2="40.665" transform="translate(141.5 332.5)"/>
+        <line id="Line_27-12" data-name="Line 27" class="cls-2" x2="72" y2="22" transform="translate(140.5 365.5)"/>
+        <line id="Line_27-13" data-name="Line 27" class="cls-2" x2="20" y2="45" transform="translate(197.5 336.5)"/>
+        <line id="Line_20-3" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(130.5 302.512)"/>
+        <line id="Line_25-4" data-name="Line 25" class="cls-2" x2="48.51" y2="40" transform="translate(260.5 243.5)"/>
+        <line id="Line_27-14" data-name="Line 27" class="cls-2" x2="15.303" y2="50.687" transform="translate(237.197 264.813)"/>
+        <line id="Line_27-15" data-name="Line 27" class="cls-2" x1="41.665" y2="24" transform="translate(266.338 296.5)"/>
+        <line id="Line_27-16" data-name="Line 27" class="cls-2" x1="40.665" y1="24" transform="translate(266.322 332.5)"/>
+        <line id="Line_27-17" data-name="Line 27" class="cls-2" x1="72" y2="22" transform="translate(235.676 365.5)"/>
+        <line id="Line_27-18" data-name="Line 27" class="cls-2" x1="20" y2="45" transform="translate(230.131 336.5)"/>
+        <line id="Line_20-4" data-name="Line 20" class="cls-2" y2="44.976" transform="translate(318.49 302.512)"/>
+        <line id="Line_28-2" data-name="Line 28" class="cls-2" x1="42" transform="translate(203.5 324.5)"/>
       </g>
-      <g
-         id="Ellipse_29"
-         data-name="Ellipse 29"
-         class="cls-4"
-         transform="translate(70.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1115" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1117" />
+      <g id="Ellipse_29" data-name="Ellipse 29" class="cls-4" transform="translate(70.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_32"
-         data-name="Ellipse 32"
-         class="cls-4"
-         transform="translate(246.835 241)">
-        <circle
-           class="cls-13"
-           cx="16"
-           cy="16"
-           r="16"
-           id="circle1120" />
-        <circle
-           class="cls-14"
-           cx="16"
-           cy="16"
-           r="15.5"
-           id="circle1122" />
+      <g id="Ellipse_32" data-name="Ellipse 32" class="cls-4" transform="translate(246.835 241)">
+        <circle class="cls-13" cx="16" cy="16" r="16"/>
+        <circle class="cls-14" cx="16" cy="16" r="15.5"/>
       </g>
-      <g
-         id="Ellipse_30"
-         data-name="Ellipse 30"
-         class="cls-4"
-         transform="translate(157 190)">
-        <circle
-           class="cls-13"
-           cx="17"
-           cy="17"
-           r="17"
-           id="circle1125" />
-        <circle
-           class="cls-14"
-           cx="17"
-           cy="17"
-           r="16.5"
-           id="circle1127" />
+      <g id="Ellipse_30" data-name="Ellipse 30" class="cls-4" transform="translate(157 190)">
+        <circle class="cls-13" cx="17" cy="17" r="17"/>
+        <circle class="cls-14" cx="17" cy="17" r="16.5"/>
       </g>
-      <g
-         id="Ellipse_32-2"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(94.438 379.512) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1130" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1132" />
+      <g id="Ellipse_32-2" data-name="Ellipse 32" class="cls-3" transform="translate(94.438 379.512) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(94.438 448.79) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1135" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1137" />
+      <g id="Ellipse_35" data-name="Ellipse 35" class="cls-3" transform="translate(94.438 448.79) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_36"
-         data-name="Ellipse 36"
-         class="cls-3"
-         transform="translate(187.664 480.436) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1140" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1142" />
+      <g id="Ellipse_36" data-name="Ellipse 36" class="cls-3" transform="translate(187.664 480.436) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(156.019 415.434) rotate(180)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1145" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1147" />
+      <g id="Ellipse_31" data-name="Ellipse 31" class="cls-3" transform="translate(156.019 415.434) rotate(180)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_32-3"
-         data-name="Ellipse 32"
-         class="cls-3"
-         transform="translate(258.552 355.564)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1150" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1152" />
+      <g id="Ellipse_32-3" data-name="Ellipse 32" class="cls-3" transform="translate(258.552 355.564)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_35-2"
-         data-name="Ellipse 35"
-         class="cls-3"
-         transform="translate(258.552 424.842)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1155" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1157" />
+      <g id="Ellipse_35-2" data-name="Ellipse 35" class="cls-3" transform="translate(258.552 424.842)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <g
-         id="Ellipse_31-2"
-         data-name="Ellipse 31"
-         class="cls-3"
-         transform="translate(196.578 391.486)">
-        <circle
-           class="cls-13"
-           cx="11.974"
-           cy="11.974"
-           r="11.974"
-           id="circle1160" />
-        <circle
-           class="cls-14"
-           cx="11.974"
-           cy="11.974"
-           r="11.474"
-           id="circle1162" />
+      <g id="Ellipse_31-2" data-name="Ellipse 31" class="cls-3" transform="translate(196.578 391.486)">
+        <circle class="cls-13" cx="11.974" cy="11.974" r="11.974"/>
+        <circle class="cls-14" cx="11.974" cy="11.974" r="11.474"/>
       </g>
-      <line
-         id="Line_29"
-         data-name="Line 29"
-         class="cls-2"
-         x1="49.593"
-         y2="27.492"
-         transform="translate(249.526 292.5) rotate(180)" />
-      <line
-         id="Line_31"
-         data-name="Line 31"
-         class="cls-2"
-         x1="48.563"
-         y1="26"
-         transform="translate(100.5 265.5)" />
-      <g
-         id="Group_38"
-         data-name="Group 38"
-         transform="translate(7.068 70.343)">
-        <line
-           id="Line_34"
-           data-name="Line 34"
-           class="cls-2"
-           x1="21.957"
-           y2="38.451"
-           transform="translate(453.476 204.696)" />
-        <line
-           id="Line_35"
-           data-name="Line 35"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 249.658)" />
-        <line
-           id="Line_45"
-           data-name="Line 45"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(457.196 137.658)" />
-        <line
-           id="Line_39"
-           data-name="Line 39"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(423.669 196.03)" />
-        <line
-           id="Line_41"
-           data-name="Line 41"
-           class="cls-2"
-           x1="47.734"
-           transform="translate(491.92 196.03)" />
-        <g
-           id="Group_40"
-           data-name="Group 40">
-          <line
-             id="Line_36"
-             data-name="Line 36"
-             class="cls-2"
-             x2="23.406"
-             y2="38.451"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40"
-             data-name="Line 40"
-             class="cls-2"
-             x1="21.957"
-             y2="38.451"
-             transform="translate(521.727 204.696)" />
-          <line
-             id="Line_38"
-             data-name="Line 38"
-             class="cls-2"
-             x2="25.89"
-             y2="37.856"
-             transform="translate(416.81 205.291)" />
+      <line id="Line_29" data-name="Line 29" class="cls-2" x1="49.593" y2="27.492" transform="translate(249.526 292.5) rotate(180)"/>
+      <line id="Line_31" data-name="Line 31" class="cls-2" x1="48.563" y1="26" transform="translate(100.5 265.5)"/>
+      <g id="Group_38" data-name="Group 38" transform="translate(7.068 70.343)">
+        <line id="Line_34" data-name="Line 34" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+        <line id="Line_35" data-name="Line 35" class="cls-2" x1="47.734" transform="translate(457.196 249.658)"/>
+        <line id="Line_45" data-name="Line 45" class="cls-2" x1="47.734" transform="translate(457.196 137.658)"/>
+        <line id="Line_39" data-name="Line 39" class="cls-2" x1="47.734" transform="translate(423.669 196.03)"/>
+        <line id="Line_41" data-name="Line 41" class="cls-2" x1="47.734" transform="translate(491.92 196.03)"/>
+        <g id="Group_40" data-name="Group 40">
+          <line id="Line_36" data-name="Line 36" class="cls-2" x2="23.406" y2="38.451" transform="translate(485.864 204.696)"/>
+          <line id="Line_37" data-name="Line 37" class="cls-2" x1="21.957" y2="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40" data-name="Line 40" class="cls-2" x1="21.957" y2="38.451" transform="translate(521.727 204.696)"/>
+          <line id="Line_38" data-name="Line 38" class="cls-2" x2="25.89" y2="37.856" transform="translate(416.81 205.291)"/>
         </g>
-        <g
-           id="Group_41"
-           data-name="Group 41"
-           transform="translate(0 -59)">
-          <line
-             id="Line_36-2"
-             data-name="Line 36"
-             class="cls-2"
-             y1="38.451"
-             x2="23.406"
-             transform="translate(485.864 204.696)" />
-          <line
-             id="Line_37-2"
-             data-name="Line 37"
-             class="cls-2"
-             x1="21.957"
-             y1="38.451"
-             transform="translate(453.476 204.696)" />
-          <line
-             id="Line_40-2"
-             data-name="Line 40"
-             class="cls-2"
-             x1="24.252"
-             y1="37.989"
-             transform="translate(519.432 205.157)" />
-          <line
-             id="Line_38-2"
-             data-name="Line 38"
-             class="cls-2"
-             y1="37.394"
-             x2="23.622"
-             transform="translate(417.81 205.157)" />
+        <g id="Group_41" data-name="Group 41" transform="translate(0 -59)">
+          <line id="Line_36-2" data-name="Line 36" class="cls-2" y1="38.451" x2="23.406" transform="translate(485.864 204.696)"/>
+          <line id="Line_37-2" data-name="Line 37" class="cls-2" x1="21.957" y1="38.451" transform="translate(453.476 204.696)"/>
+          <line id="Line_40-2" data-name="Line 40" class="cls-2" x1="24.252" y1="37.989" transform="translate(519.432 205.157)"/>
+          <line id="Line_38-2" data-name="Line 38" class="cls-2" y1="37.394" x2="23.622" transform="translate(417.81 205.157)"/>
         </g>
-        <g
-           id="Ellipse_38"
-           data-name="Ellipse 38"
-           class="cls-5"
-           transform="translate(498.801 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1182" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1184" />
+        <g id="Ellipse_38" data-name="Ellipse 38" class="cls-5" transform="translate(498.801 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_57"
-           data-name="Ellipse 57"
-           class="cls-5"
-           transform="translate(498.801 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1187" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1189" />
+        <g id="Ellipse_57" data-name="Ellipse 57" class="cls-5" transform="translate(498.801 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_49"
-           data-name="Ellipse 49"
-           class="cls-5"
-           transform="translate(431.229 233.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1192" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1194" />
+        <g id="Ellipse_49" data-name="Ellipse 49" class="cls-5" transform="translate(431.229 233.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_58"
-           data-name="Ellipse 58"
-           class="cls-5"
-           transform="translate(431.229 121.972)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1197" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1199" />
+        <g id="Ellipse_58" data-name="Ellipse 58" class="cls-5" transform="translate(431.229 121.972)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_50"
-           data-name="Ellipse 50"
-           class="cls-5"
-           transform="translate(532.178 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1202" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1204" />
+        <g id="Ellipse_50" data-name="Ellipse 50" class="cls-5" transform="translate(532.178 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_39"
-           data-name="Ellipse 39"
-           class="cls-5"
-           transform="translate(463.777 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1207" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1209" />
+        <g id="Ellipse_39" data-name="Ellipse 39" class="cls-5" transform="translate(463.777 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
-        <g
-           id="Ellipse_51"
-           data-name="Ellipse 51"
-           class="cls-5"
-           transform="translate(397.238 179.657)">
-          <circle
-             class="cls-13"
-             cx="15.843"
-             cy="15.843"
-             r="15.843"
-             id="circle1212" />
-          <circle
-             class="cls-14"
-             cx="15.843"
-             cy="15.843"
-             r="15.343"
-             id="circle1214" />
+        <g id="Ellipse_51" data-name="Ellipse 51" class="cls-5" transform="translate(397.238 179.657)">
+          <circle class="cls-13" cx="15.843" cy="15.843" r="15.843"/>
+          <circle class="cls-14" cx="15.843" cy="15.843" r="15.343"/>
         </g>
       </g>
-      <line
-         id="Line_32"
-         data-name="Line 32"
-         class="cls-2"
-         y1="30.526"
-         x2="0.719"
-         transform="translate(173.5 223.974)" />
-      <g
-         id="Ellipse_33"
-         data-name="Ellipse 33"
-         class="cls-6"
-         transform="translate(127 250)">
-        <circle
-           class="cls-13"
-           cx="47"
-           cy="47"
-           r="47"
-           id="circle1219" />
-        <circle
-           class="cls-14"
-           cx="47"
-           cy="47"
-           r="46"
-           id="circle1221" />
+      <line id="Line_32" data-name="Line 32" class="cls-2" y1="30.526" x2="0.719" transform="translate(173.5 223.974)"/>
+      <g id="Ellipse_33" data-name="Ellipse 33" class="cls-6" transform="translate(127 250)">
+        <circle class="cls-13" cx="47" cy="47" r="47"/>
+        <circle class="cls-14" cx="47" cy="47" r="46"/>
       </g>
-      <text
-         id="Decentralized_Governance"
-         data-name="Decentralized Governance"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="515.11102"
-         y="511">
-        <tspan
-           x="445.52301"
-           y="511"
-           id="tspan1224">去中心化的表决</tspan>
-      </text>
-      <text
-         id="Centralized_Point_of_Failure"
-         data-name="Centralized Point of Failure"
-         class="cls-8"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffa5a5"
-         x="208.78799"
-         y="511">
-        <tspan
-           x="137.67"
-           y="511"
-           id="tspan1227">中心化的坏处</tspan>
-      </text>
-      <text
-         id="Without_DAO"
-         data-name="Without DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="173.87587"
-         y="166">
-        <tspan
-           x="113.27686"
-           y="166"
-           id="tspan1230">不使用 DAO</tspan>
-      </text>
-      <text
-         id="With_DAO"
-         data-name="With DAO"
-         class="cls-9"
-         style="font-weight:200;font-size:22px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="483.31485"
-         y="166">
-        <tspan
-           x="438.18185"
-           y="166"
-           id="tspan1233">使用 DAO</tspan>
-      </text>
-      <text
-         id="Contributors"
-         class="cls-7"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff"
-         x="341.78"
-         y="298">
-        <tspan
-           x="308.67801"
-           y="298"
-           id="tspan1236">贡献者</tspan>
-      </text>
-      <text
-         id="Traders"
-         class="cls-7"
-         transform="translate(329,351)"
-         style="font-weight:300;font-size:12px;font-family:'IBM Plex Sans', sans-serif;fill:#ffffff">
-        <tspan
-           x="-20.136"
-           y="0"
-           id="tspan1239">交易商</tspan>
-      </text>
-      <text
-         id="_"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(213 347)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1242">₿</tspan>
-      </text>
-      <text
-         id="_2"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(177 359)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1245">₿</tspan>
-      </text>
-      <text
-         id="_3"
-         data-name="₿"
-         class="cls-10"
-         transform="translate(138 349)">
-        <tspan
-           x="-2.894"
-           y="0"
-           id="tspan1248">₿</tspan>
-      </text>
-      <line
-         id="Line_42"
-         data-name="Line 42"
-         class="cls-11"
-         x2="69"
-         transform="translate(40.5 320.5)" />
-      <line
-         id="Line_44"
-         data-name="Line 44"
-         class="cls-11"
-         x2="79"
-         transform="translate(567.5 320.5)" />
-      <line
-         id="Line_43"
-         data-name="Line 43"
-         class="cls-11"
-         x2="407.71399"
-         x1="245.714"
-         y1="320.5"
-         y2="320.5"
-         style="fill:none;stroke:#ffffff;stroke-width:0.5px" />
-      <text
-         id="BSQ"
-         class="cls-12"
-         transform="translate(437 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1254">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-2"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(489 338)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1257">BSQ</tspan>
-      </text>
-      <text
-         id="BSQ-3"
-         data-name="BSQ"
-         class="cls-12"
-         transform="translate(543 361)">
-        <tspan
-           x="-7.528"
-           y="0"
-           id="tspan1260">BSQ</tspan>
-      </text>
+      <text id="dao_why_decent_governance" data-name="Decentralized Governance" class="cls-7" transform="translate(487.835 511)"><tspan x="-69.588" y="0">Decentralized Governance</tspan></text>
+      <text id="dao_why_cpof" data-name="Centralized Point of Failure" class="cls-8" transform="translate(173.835 511)"><tspan x="-71.118" y="0">Centralized Point of Failure</tspan></text>
+      <text id="dao_why_without" data-name="Without DAO" class="cls-9" transform="translate(174 166)"><tspan x="-60.599" y="0">Without DAO</tspan></text>
+      <text id="dao_why_with" data-name="With DAO" class="cls-9" transform="translate(485 166)"><tspan x="-45.133" y="0">With DAO</tspan></text>
+      <text id="dao_why_contributors" class="cls-7" transform="translate(329 298)"><tspan x="-33.102" y="0">Contributors</tspan></text>
+      <text id="dao_why_traders" class="cls-7" transform="translate(329 351)"><tspan x="-20.136" y="0">Traders</tspan></text>
+      <text id="_" data-name="₿" class="cls-10" transform="translate(213 347)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_2" data-name="₿" class="cls-10" transform="translate(177 359)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <text id="_3" data-name="₿" class="cls-10" transform="translate(138 349)"><tspan x="-2.894" y="0">₿</tspan></text>
+      <line id="Line_42" data-name="Line 42" class="cls-11" x2="69" transform="translate(40.5 320.5)"/>
+      <line id="Line_44" data-name="Line 44" class="cls-11" x2="79" transform="translate(567.5 320.5)"/>
+      <line id="Line_43" data-name="Line 43" class="cls-11" x2="162" transform="translate(247.5 320.5)"/>
+      <text id="BSQ" class="cls-12" transform="translate(437 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-2" data-name="BSQ" class="cls-12" transform="translate(489 338)"><tspan x="-7.528" y="0">BSQ</tspan></text>
+      <text id="BSQ-3" data-name="BSQ" class="cls-12" transform="translate(543 361)"><tspan x="-7.528" y="0">BSQ</tspan></text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Most importantly, this PR updates the `id` field for all SVG images on the DAO page so that the new translations update script introduced in #386 can work. It also refines text positioning so future changes can be applied easily.

In addition, SVG text itself is updated to reflect the most recent revisions in Transifex.

To review, compare the following page across all languages to the existing https://bisq.network/dao/ page across all languages:
https://deploy-preview-385--bisq-website.netlify.app/dao/

Cross-reference any inconsistencies with the `dao_images` list in `_data/<lang>.yml`.