### PR TITLE
Simplify main_nav yml

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Downloads
-  liLearnMore: Mehr erfahren
-  liDocumentation: Dokumentation
-  liBlog: Blog
-  liCommunity: Community
-  buttonDownloads: Downloads
-  links:
-    - title: Erste Schritte
-      url: /getting-started/
-    - title: Bisq DAO
-      url: /de/dao/
-    - title: Statistiken
-      url: /de/stats/
-    - title: FAQ
-      url: /de/faq/
-    - title: Märkte
-      url: /de/markets/
-  mobile_links:
-    - title: Community
-      url: /de/community/
-    - title: Blog
-      url: /blog/
-    - title: Dokumentation
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Downloads
+  learnMore: Mehr erfahren
+  documentation: Dokumentation
+  blog: Blog
+  community: Community
+  gettingStarted: Erste Schritte
+  bisqDAO: Bisq DAO
+  statistics: Statistiken
+  faq: FAQ
+  markets: Märkte
 
 footer:
   notificationApp: Bisq Mobile Benachrichtigungs-App

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Downloads
-  liLearnMore: Learn More
-  liDocumentation: Documentation
-  liBlog: Blog
-  liCommunity: Community
-  buttonDownloads: Downloads
-  links:
-    - title: Getting Started
-      url: /getting-started/
-    - title: Bisq DAO
-      url: /dao/
-    - title: Statistics
-      url: /stats/
-    - title: FAQ
-      url: /faq/
-    - title: Markets
-      url: /markets/
-  mobile_links:
-    - title: Community
-      url: /community/
-    - title: Blog
-      url: /blog/
-    - title: Documentation
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Downloads
+  learnMore: Learn More
+  documentation: Documentation
+  blog: Blog
+  community: Community
+  gettingStarted: Getting Started
+  bisqDAO: Bisq DAO
+  statistics: Statistics
+  faq: FAQ
+  markets: Markets
 
 footer:
   notificationApp: Bisq mobile notification App

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Descargas
-  liLearnMore: Aprender más
-  liDocumentation: Documentación
-  liBlog: Blog
-  liCommunity: Comunidad
-  buttonDownloads: Descargas
-  links:
-    - title: Empezando
-      url: /getting-started/
-    - title: DAO Bisq
-      url: /es/dao/
-    - title: Estadísticas
-      url: /es/stats/
-    - title: FAQ
-      url: /es/faq/
-    - title: Mercados
-      url: /es/markets/
-  mobile_links:
-    - title: Comunidad
-      url: /es/community/
-    - title: Blog
-      url: /blog/
-    - title: Documentación
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Descargas
+  learnMore: Aprender más
+  documentation: Documentación
+  blog: Blog
+  community: Comunidad
+  gettingStarted: Empezando
+  bisqDAO: DAO Bisq
+  statistics: Estadísticas
+  faq: FAQ
+  markets: Mercados
 
 footer:
   notificationApp: App de notificaciones de celular Bisq

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Téléchargements
-  liLearnMore: En savoir plus
-  liDocumentation: Documentation
-  liBlog: Blog
-  liCommunity: Communauté
-  buttonDownloads: Téléchargements
-  links:
-    - title: Mise en route
-      url: /getting-started/
-    - title: La DAO de Bisq
-      url: /fr/dao/
-    - title: Statistiques
-      url: /fr/stats/
-    - title: FAQ
-      url: /fr/faq/
-    - title: Marchés
-      url: /fr/markets/
-  mobile_links:
-    - title: Communauté
-      url: /fr/community/
-    - title: Blog
-      url: /blog/
-    - title: Documentation
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Téléchargements
+  learnMore: En savoir plus
+  documentation: Documentation
+  blog: Blog
+  community: Communauté
+  gettingStarted: Mise en route
+  bisqDAO: Bisq DAO
+  statistics: Statistiques
+  faq: FAQ
+  markets: Marchés
 
 footer:
   notificationApp: "App Bisq mobile de notification "

--- a/_data/ja.yml
+++ b/_data/ja.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: ダウンロード
-  liLearnMore: もっと知る
-  liDocumentation: ドキュメント
-  liBlog: ブログ
-  liCommunity: コミュニティ
-  buttonDownloads: ダウンロード
-  links:
-    - title: 始めに
-      url: /getting-started/
-    - title: Bisq DAO
-      url: /ja/dao/
-    - title: 統計
-      url: /ja/stats/
-    - title: FAQ
-      url: /ja/faq/
-    - title: 市場
-      url: /ja/markets/
-  mobile_links:
-    - title: コミュニティー
-      url: /ja/community/
-    - title: ブログ
-      url: /blog/
-    - title: ドキュメンテーション
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: ダウンロード
+  learnMore: もっと知る
+  documentation: ドキュメンテーション
+  blog: ブログ
+  community: コミュニティ
+  gettingStarted: 始めに
+  bisqDAO: Bisq DAO
+  statistics: 統計
+  faq: FAQ
+  markets: 市場
 
 footer:
   notificationApp: Bisqモバイル通知アプリ

--- a/_data/ja.yml
+++ b/_data/ja.yml
@@ -1,7 +1,7 @@
 main_nav:
   downloads: ダウンロード
   learnMore: もっと知る
-  documentation: ドキュメンテーション
+  documentation: ドキュメント
   blog: ブログ
   community: コミュニティ
   gettingStarted: 始めに

--- a/_data/pt-BR.yml
+++ b/_data/pt-BR.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Downloads
-  liLearnMore: Saiba Mais
-  liDocumentation: Documentação
-  liBlog: Blog
-  liCommunity: Comunidade
-  buttonDownloads: Downloads
-  links:
-    - title: Começando
-      url: /getting-started/
-    - title: A DAO Bisq
-      url: /pt-BR/dao/
-    - title: Estatísticas
-      url: /pt-BR/stats/
-    - title: FAQ
-      url: /pt-BR/faq/
-    - title: Mercados
-      url: /pt-BR/markets/
-  mobile_links:
-    - title: Comunidade
-      url: /pt-BR/community/
-    - title: Blog
-      url: /blog/
-    - title: Documentation
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Downloads
+  learnMore: Saiba Mais
+  documentation: Documentação
+  blog: Blog
+  community: Comunidade
+  gettingStarted: Começando
+  bisqDAO: A DAO Bisq
+  statistics: Estatísticas
+  faq: FAQ
+  markets: Mercados
 
 footer:
   notificationApp: App de notificações da Bisq

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Downloads
-  liLearnMore: Aprender Mais
-  liDocumentation: Documentação
-  liBlog: Blog
-  liCommunity: Comunidade
-  buttonDownloads: Downloads
-  links:
-    - title: Começar
-      url: /getting-started/
-    - title: OAD do Bisq
-      url: /pt-PT/dao/
-    - title: Estatísticas
-      url: /pt-PT/stats/
-    - title: FAQ
-      url: /pt-PT/faq/
-    - title: Mercados
-      url: /pt-PT/markets/
-  mobile_links:
-    - title: Comunidade
-      url: /pt-PT/community/
-    - title: Blog
-      url: /blog/
-    - title: Documentation
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Downloads
+  learnMore: Aprender Mais
+  documentation: Documentation
+  blog: Blog
+  community: Comunidade
+  gettingStarted: Começar
+  bisqDAO: OAD do Bisq
+  statistics: Estatísticas
+  faq: FAQ
+  markets: Mercados
 
 footer:
   notificationApp: App de notificação móvel do Bisq

--- a/_data/ru.yml
+++ b/_data/ru.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: Загрузить
-  liLearnMore: Узнать больше
-  liDocumentation: Документация
-  liBlog: Блог
-  liCommunity: Сообщество
-  buttonDownloads: Загрузить
-  links:
-    - title: Начало работы
-      url: /getting-started/
-    - title: ДАО Bisq
-      url: /ru/dao/
-    - title: Статистика
-      url: /ru/stats/
-    - title: ЧаВо
-      url: /ru/faq/
-    - title: Рынки
-      url: /ru/markets/
-  mobile_links:
-    - title: Сообщество
-      url: /ru/community/
-    - title: Блог
-      url: /blog/
-    - title: Документация
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: Загрузить
+  learnMore: Узнать больше
+  documentation: Документация
+  blog: Блог
+  community: Сообщество
+  gettingStarted: Начало работы
+  bisqDAO: ДАО Bisq
+  statistics: Статистика
+  faq: ЧаВо
+  markets: Рынки
 
 footer:
   notificationApp: Мобильное приложение Bisq

--- a/_data/zh-CN.yml
+++ b/_data/zh-CN.yml
@@ -1,29 +1,14 @@
 main_nav:
-  liDownloads: 下载
-  liLearnMore: 了解更多
-  liDocumentation: 文档
-  liBlog: 博客
-  liCommunity: 社区
-  buttonDownloads: 下载
-  links:
-    - title: 快速入门
-      url: /getting-started/
-    - title: Bisq DAO
-      url: /zh-CN/dao/
-    - title: 统计数据
-      url: /zh-CN/stats/
-    - title: FAQ
-      url: /zh-CN/faq/
-    - title: 市场
-      url: /zh-CN/markets/
-  mobile_links:
-    - title: 社区
-      url: /zh-CN/community/
-    - title: 博客
-      url: /blog/
-    - title: 文档
-      url: https://docs.bisq.network/
-      target: _blank
+  downloads: 下载
+  learnMore: 了解更多
+  documentation: 文档
+  blog: 博客
+  community: 社区
+  gettingStarted: 快速入门
+  bisqDAO: Bisq DAO
+  statistics: 统计数据
+  faq: FAQ
+  markets: 市场
 
 footer:
   notificationApp: Bisq 通知应用程序

--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -3,6 +3,7 @@
   <a class="navbar-brand" href="{% lingual_link home %}"><img src="/images/bisq-logo.svg" height="30" loading="lazy"/></a>
 
   <!-- Language selector for mobile -->
+
   {% if page.en-only == false %}
   <div class="dropdown mobile-language-selector more-info-desktop">
     <button class="btn btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -21,7 +22,6 @@
   </div>
   {% endif %}
 
-
   <button class="navbar-toggler pr-3 pr-md-0 collapsed" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
@@ -30,71 +30,79 @@
 
     <ul class="navbar-nav ml-auto">
 
-      <!-- MOBILE MENU -->
+      {% assign mainNavLabels = site.data[page.lang].main_nav %}
 
-      {% for item in site.data[page.lang].main_nav.links %}
-        <li class="nav-item {% if page.url == item.url | append: '/' %}current{% endif %}">
-          {% if item.target == "_blank" %}
-            <a class="nav-link" rel="noopener" target="{{ item.target }}" href="{{ item.url }}">{{ item.title }}</a>
-          {% else %}
-            <a class="nav-link" href="{{ item.url }}">{{ item.title }}</a>
-          {% endif %}
-        </li>
-      {% endfor %}
+      <!-- main links for desktop and mobile -->
 
-      {% for item in site.data[page.lang].main_nav.mobile_links %}
-        <li class="downloads-mobile nav-item {% if page.url == item.url | append: '/' %}current{% endif %}">
-          {% if item.target == "_blank" %}
-            <a class="nav-link" rel="noopener" target="{{ item.target }}" href="{{ item.url }}">{{ item.title }}</a>
-          {% else %}
-            <a class="nav-link" href="{{ item.url }}">{{ item.title }}</a>
-          {% endif %}
-        </li>
-      {% endfor %}
-
-      {% assign item = site.data[page.lang].main_nav %}
-      <li class="downloads-mobile nav-item {% if page.url == item.url %}current{% endif %}">
-          <a class="nav-link" href="{% lingual_link downloads %}">{{ item.liDownloads }}</a>
+      <li class="nav-item {% if page.url == '/getting-started/' %}current{% endif %}">
+        <a class="nav-link" href="/getting-started">{{ mainNavLabels.gettingStarted }}</a>
+      </li>
+      <li class="nav-item {% if page.url == '/dao/' %}current{% endif %}">
+        <a class="nav-link" href="{% lingual_link dao %}">{{ mainNavLabels.bisqDAO }}</a>
+      </li>
+      <li class="nav-item {% if page.url == '/stats/' %}current{% endif %}">
+        <a class="nav-link" href="{% lingual_link stats %}">{{ mainNavLabels.statistics }}</a>
+      </li>
+      <li class="nav-item {% if page.url == '/faq/' %}current{% endif %}">
+        <a class="nav-link" href="{% lingual_link faq %}">{{ mainNavLabels.faq }}</a>
+      </li>
+      <li class="nav-item {% if page.url == '/markets/' %}current{% endif %}">
+        <a class="nav-link" href="{% lingual_link markets %}">{{ mainNavLabels.markets }}</a>
       </li>
 
-      <!-- DESKTOP MENU -->
+      <!-- additional links for mobile menu (these show in "learn more" dropdown on desktop) -->
+
+      <li class="downloads-mobile nav-item {% if page.url == '/community/' %}current{% endif %}">
+        <a class="nav-link" href="{% lingual_link community %}">{{ mainNavLabels.community }}</a>
+      </li>
+      <li class="downloads-mobile nav-item">
+        <a class="nav-link" href="/blog">{{ mainNavLabels.blog }}</a>
+      </li>
+      <li class="downloads-mobile nav-item">
+        <a class="nav-link" href="https://docs.bisq.network" target="_blank">{{ mainNavLabels.documentation }}</a>
+      </li>
+      <li class="downloads-mobile nav-item">
+        <a class="nav-link" href="{% lingual_link downloads %}">{{ mainNavLabels.downloads }}</a>
+      </li>
+
+      <!-- dropdown menus for desktop -->
 
       <li class="downloads-desktop more-info-desktop nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="learnMoreDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{ item.liLearnMore }}
+          {{ mainNavLabels.learnMore }}
         </a>
         <div class="dropdown-menu dropdown-menu-right shadow-lg" aria-labelledby="learnMoreDropdown">
           <div class="dropdown-item btn-icon">
             <div class="float-right">
-              <a href="https://docs.bisq.network/" target='_blank'>{{ item.liDocumentation }}</a>
+              <a href="https://docs.bisq.network/" target='_blank'>{{ mainNavLabels.documentation }}</a>
             </div>
           </div>
 
           <div class="dropdown-item btn-icon">
             <div class="float-right">
-              <a href="/blog/">{{ item.liBlog }}</a>
+              <a href="/blog/">{{ mainNavLabels.blog }}</a>
             </div>
           </div>
 
           <div class="dropdown-item btn-icon">
             <div class="float-right">
-              <a href="{% lingual_link community %}">{{ item.liCommunity }}</a>
+              <a href="{% lingual_link community %}">{{ mainNavLabels.community }}</a>
             </div>
           </div>
         </div>
       </li>
 
-
       <li class="downloads-desktop nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="downloadDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{ item.buttonDownloads }}
+          {{ mainNavLabels.downloads }}
         </a>
         <div class="dropdown-menu dropdown-menu-right shadow-lg" aria-labelledby="downloadDropdown">
           {% include os_selector_options.html %}
         </div>
       </li>
 
-      <!-- Language selector for desktop -->
+      <!-- language selector for desktop -->
+
       {% if page.en-only == false %}
       <li class="downloads-desktop nav-item dropdown more-info-desktop language-selector">
         <a class="nav-link dropdown-toggle visible-language" href='#' id="languageSelectorDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -112,7 +120,6 @@
         </div>
       </li>
       {% endif %}
-
 
       <li class="nav-item">
         <div class="mode-toggle nav-link"><img alt="mode toggle" src="/images/mode-toggle.svg" /></div>

--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -37,22 +37,22 @@
       <li class="nav-item {% if page.url == '/getting-started/' %}current{% endif %}">
         <a class="nav-link" href="/getting-started">{{ mainNavLabels.gettingStarted }}</a>
       </li>
-      <li class="nav-item {% if page.url == '/dao/' %}current{% endif %}">
+      <li class="nav-item {% is_current_page dao %}">
         <a class="nav-link" href="{% lingual_link dao %}">{{ mainNavLabels.bisqDAO }}</a>
       </li>
-      <li class="nav-item {% if page.url == '/stats/' %}current{% endif %}">
+      <li class="nav-item {% is_current_page stats %}">
         <a class="nav-link" href="{% lingual_link stats %}">{{ mainNavLabels.statistics }}</a>
       </li>
-      <li class="nav-item {% if page.url == '/faq/' %}current{% endif %}">
+      <li class="nav-item {% is_current_page faq %}">
         <a class="nav-link" href="{% lingual_link faq %}">{{ mainNavLabels.faq }}</a>
       </li>
-      <li class="nav-item {% if page.url == '/markets/' %}current{% endif %}">
+      <li class="nav-item {% is_current_page markets %}">
         <a class="nav-link" href="{% lingual_link markets %}">{{ mainNavLabels.markets }}</a>
       </li>
 
       <!-- additional links for mobile menu (these show in "learn more" dropdown on desktop) -->
 
-      <li class="downloads-mobile nav-item {% if page.url == '/community/' %}current{% endif %}">
+      <li class="downloads-mobile nav-item">
         <a class="nav-link" href="{% lingual_link community %}">{{ mainNavLabels.community }}</a>
       </li>
       <li class="downloads-mobile nav-item">

--- a/_plugins/custom_tag.rb
+++ b/_plugins/custom_tag.rb
@@ -14,3 +14,21 @@ class LingualLink < Liquid::Tag
 end
 
 Liquid::Template.register_tag('lingual_link', LingualLink)
+
+class IsCurrentPage < Liquid::Tag
+  def initialize(tag_name, dest, _tokens)
+    super
+    @dest = dest
+  end
+
+  def render(context)
+    urlParts = ( context.environments.first["page"]["url"] ).split('/')
+    urlParts.each_with_index do |part,index|
+      if( ( part.strip == @dest.strip ) && ( index == 2 || index == 1 ) )
+        return 'current'
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('is_current_page', IsCurrentPage)


### PR DESCRIPTION
This PR simplifies the YML markup for ` _includes/main_nav.html`.

Previously, the `main_nav` markup was broken into parts and included URLs, which was unnecessary and confusing for translators. These changes condense the `main_nav` markup into a succinct list.

## Review Guidance

A thorough visual review of the main navigation menu should suffice to review this pull request. Visit https://deploy-preview-387--bisq-website.netlify.app/ and make sure the main navigation menu at the top matches what's on https://bisq.network for all 9 languages—desktop and mobile. There should be no missing links, etc. Ideally no colliding text either (e.g., from text that's too long).