### PR TITLE
Add report for dao cycle 15

### DIFF
--- a/_posts/2020-08-17-cycle-15-results.md
+++ b/_posts/2020-08-17-cycle-15-results.md
@@ -26,7 +26,7 @@ Please note that the proof-of-burn transactions and arbitrator reimbursements do
 Compensation by function:
 
 **Dev**|**Growth**|**Ops**|**Support**|**Admin**|**Total BSQ**
------|-----|-----|-----|-----|-----|-----
+-----|-----|-----|-----|-----|-----
 28,737|7,351|13,167|12,002|307|61,566
 
 See more details by browsing the [compensation requests on GitHub](https://github.com/bisq-network/compensation/milestone/6?closed=1).

--- a/_posts/2020-08-17-cycle-15-results.md
+++ b/_posts/2020-08-17-cycle-15-results.md
@@ -1,0 +1,50 @@
+---
+layout: post
+title: "Bisq DAO Cycle 15: Results"
+author: Steve Jain
+excerpt: "Cycle 15 of the Bisq DAO ended at block 641,946 on August 02 2020. This post covers its results. <br><br>"
+lang: en
+---
+
+This post summarizes the results of Cycle 15 of the Bisq DAO.
+
+### Summary
+
+* Cycle took place between blocks 637,267 and 641,946
+  * Calendar dates: 07/01/2020 - 08/02/2020
+* 33 proposals
+  * 2 generic proposals
+  * 2 proposals to change a parameter
+  * 4 reimbursement proposals
+  * 25 compensation requests
+* 368 votes cast
+* 95,708.01 BSQ issued for compensation (169,784.38 BSQ was issued in total, of which 46,142.70 was for reimbursing [an arbitrator](https://bisq.wiki/Arbitrator) and 27,933.67 was for a user-initiated reimbursement)
+* 7,962.94 BSQ was burned through fees (72,062.94 BSQ was burned in total, of which 64,000 was from proof-of-burn transactions that consisted of BTC trading fees and deposits from arbitrated trades)
+
+Please note that the proof-of-burn transactions and arbitrator reimbursements do not map neatly to DAO cycles, meaning that some of the funds involved with these issuances (and burns) are from previous cycles.
+
+### Proposal Details
+
+**Migrate the Bisq Markets API service to the bisq.market domain name**
+
+Generic proposal ([link](https://bisq.network/dao-proposals/229){:target="_blank"})
+
+_Accepted_
+
+This proposal approved the migration of the Bisq markets API from the `bisq.network` domain to a new `bisq.market` domain to improve decentralization of the ownership of key Bisq domain names. This development sparked the start of [a new project](https://github.com/bisq-network/projects/issues/41) to revamp the markets website as a dashboard for market activity and DAO reporting.
+
+**Update BSQ fees**
+
+Parameter change proposal ([link](https://bisq.network/dao-proposals/238){:target="_blank"})
+
+_Accepted_
+
+This proposal changed the BSQ maker and taker fees in accordance with the convention to [keep BSQ fees at 50% of BTC fees](https://github.com/bisq-network/proposals/issues/202).
+
+**Reinstate BCH trading on Bisq**
+
+Generic proposal ([link](https://bisq.network/dao-proposals/240){:target="_blank"})
+
+_Rejected_
+
+The DAO overwhelmingly rejected this proposal, with similar decisiveness as [the rejection of BCH the first time](https://github.com/bisq-network/proposals/issues/61). The proposal garnered 531,331.83 BSQ of voting weight, but only 0.01% of it was in favor.

--- a/_posts/2020-08-17-cycle-15-results.md
+++ b/_posts/2020-08-17-cycle-15-results.md
@@ -18,10 +18,18 @@ This post summarizes the results of Cycle 15 of the Bisq DAO.
   * 4 reimbursement proposals
   * 25 compensation requests
 * 368 votes cast
-* 95,708.01 BSQ issued for compensation (169,784.38 BSQ was issued in total, of which 46,142.70 was for reimbursing [an arbitrator](https://bisq.wiki/Arbitrator) and 27,933.67 was for a user-initiated reimbursement)
+* 61,566.31 BSQ issued for compensation (169,784.38 BSQ was issued in total, of which 80,284.40 was for reimbursing [an arbitrator](https://bisq.wiki/Arbitrator) and 27,933.67 was for a user-initiated reimbursement)
 * 7,962.94 BSQ was burned through fees (72,062.94 BSQ was burned in total, of which 64,000 was from proof-of-burn transactions that consisted of BTC trading fees and deposits from arbitrated trades)
 
 Please note that the proof-of-burn transactions and arbitrator reimbursements do not map neatly to DAO cycles, meaning that some of the funds involved with these issuances (and burns) are from previous cycles.
+
+Compensation by function:
+
+**Dev**|**Growth**|**Ops**|**Support**|**Admin**|**Total BSQ**
+-----|-----|-----|-----|-----|-----|-----
+28,737|7,351|13,167|12,002|307|61,566
+
+See more details by browsing the [compensation requests on GitHub](https://github.com/bisq-network/compensation/milestone/6?closed=1).
 
 ### Proposal Details
 


### PR DESCRIPTION
Standard monthly report. 

~I didn't add breakdown of issuance by team because the issuance in the software doesn't match output from jmacxx's script. I will reconcile them, but that will take some time, and I would prefer to get this published quicker.~

(issuance breakdown is now added)