### PR TITLE
Use the new bisq.markets API instead of markets.bisq.network

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,7 +49,7 @@
               </div>
               <div class="virtual-column">
                 <li>
-                  <a href="https://markets.bisq.network/api/" target="_blank" rel="noopener">{{ item.liMarketData }}</a>
+                  <a href="https://bisq.markets/api/" target="_blank" rel="noopener">{{ item.liMarketData }}</a>
                 </li>
               </div>
               <!--

--- a/js/markets.js
+++ b/js/markets.js
@@ -117,7 +117,7 @@ function getTrades( pair ) {
     if( !pair ) {
 
         pair = 'all';
-        jsonUrl = 'https://markets.bisq.network/api/trades?market=all&format=jsonpretty';
+        jsonUrl = 'https://bisq.markets/api/trades?market=all&format=jsonpretty';
 
         $.get( jsonUrl, function( data ) {
 
@@ -149,7 +149,7 @@ function getTrades( pair ) {
 
     } else {
 
-        jsonUrl = 'https://markets.bisq.network/api/trades?market=' + pair;
+        jsonUrl = 'https://bisq.markets/api/trades?market=' + pair;
 
         $.get( jsonUrl, function( data ) {
 
@@ -203,7 +203,7 @@ function getOffers( pair ){
         return;
     }
 
-    var jsonUrl = 'https://markets.bisq.network/api/offers?market=' + pair + '&format=jsonpretty';
+    var jsonUrl = 'https://bisq.markets/api/offers?market=' + pair + '&format=jsonpretty';
 
     $.getJSON( jsonUrl, function( data ) {
 
@@ -268,12 +268,12 @@ function buildData( jsonUrl ){
     if( !pair || pair === 'all' ) {
 
         pair = 'btc';
-        jsonUrl = "https://markets.bisq.network/api/volumes?basecurrency=btc&milliseconds=true&timestamp=no&fillgaps=&interval=day";
+        jsonUrl = "https://bisq.markets/api/volumes?basecurrency=btc&milliseconds=true&timestamp=no&fillgaps=&interval=day";
         getTrades();
 
     } else {
 
-        jsonUrl = 'https://markets.bisq.network/api/hloc?market=' + pair + '&timestamp=no' + '&interval=day' + '&timestamp_from=' + '&timestamp_to=';
+        jsonUrl = 'https://bisq.markets/api/hloc?market=' + pair + '&timestamp=no' + '&interval=day' + '&timestamp_from=' + '&timestamp_to=';
         getTrades( pair );
         getOffers( pair );
 


### PR DESCRIPTION
This PR modifies the bisq.network website to use the [new Bisq Markets API implementation](https://github.com/mempool/mempool/pull/107) as per https://github.com/bisq-network/projects/issues/41

The new API implementation is now live at bisq.markets, example query https://bisq.markets/api/offers?market=bsq_btc