### PR TITLE
Remove color covering volume bars in darkmode

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1574,8 +1574,12 @@ body.dark-mode .plain-stat-container .stat-label {
 }
 
 
-body.dark-mode rect.highcharts-plot-background, body.dark-mode svg.highcharts-root rect{
-    fill: #1d1d1d;
+.highcharts-plot-background {
+    display: none;
+}
+
+.dark-mode .highcharts-series-1 rect {
+    fill:#111
 }
 
 body.dark-mode .chart-stat-container text {


### PR DESCRIPTION
<!-------------------------------------

IMPORTANT: Please read.

Thanks for helping to improve the Bisq website.

If you're just helping out and don't expect compensation for this 
contribution, thank you—please skip the note below and proceed.

If you're expecting compensation from the Bisq DAO for this pull request,
please make sure you've corresponded with the repo's maintainer to
ensure it's work that is currently prioritized and budgeted.

You can do this by opening an issue explaining your proposed changes and
cost, or by floating the idea in the #website channel on 
Keybase (https://keybase.io/team/bisq).

For more details, see this wiki 
article (https://bisq.wiki/Growth_Team#Processes).

-------------------------------------->
