### PR TITLE
Temporarily remove monitor.bisq.network links

### DIFF
--- a/_layouts/page_stats.html
+++ b/_layouts/page_stats.html
@@ -66,4 +66,5 @@ layout: page
 
 
 <br>
-{{ item.pNetworkLoad }}
+<!--Below line hidden temporarily until monitor site gets fixed:
+{{ item.pNetworkLoad }}-->


### PR DESCRIPTION
Commented out the monitor for now given it's been broken for a year or
so, which could be wrongly interpreted as "Bisq itself has problems".

Files affected: _data/*.yml

See:
- https://github.com/bisq-network/bisq/issues/5297#issuecomment-927376913
- https://github.com/bisq-network/bisq/discussions/5340
- https://github.com/bisq-network/compensation/issues/685#issuecomment-927377283

<!-------------------------------------

IMPORTANT: Please read.

Thanks for helping to improve the Bisq website.

If you're just helping out and don't expect compensation for this 
contribution, thank you—please skip the note below and proceed.

If you're expecting compensation from the Bisq DAO for this pull request,
please make sure you've corresponded with the repo's maintainer to
ensure it's work that is currently prioritized and budgeted.

You can do this by opening an issue explaining your proposed changes and
cost, or by floating the idea in the #website channel on 
Keybase (https://keybase.io/team/bisq).

For more details, see this wiki 
article (https://bisq.wiki/Growth_Team#Processes).

-------------------------------------->
