### PR TITLE
Add /bisq-easy redirect and link to it from blog

### DIFF
--- a/_posts/2024-03-16-bisq-2-now-in-beta.md
+++ b/_posts/2024-03-16-bisq-2-now-in-beta.md
@@ -17,7 +17,7 @@ After nearly three years in development, we're thrilled to announce the first in
 Getting started with Bisq 2 is easy:
 
 1. Get Bisq 2 from the [downloads page](/downloads#bisq2)
-2. Try the new Bisq Easy trade protocol
+2. Try the new [Bisq Easy](/bisq-easy) trade protocol
 3. Share your feedback in the integrated p2p group chat
 
 Note: If you're already running Bisq 1, carry on! Bisq 2 is a separate application and will install and run alongside Bisq 1 without issue.

--- a/_redirects
+++ b/_redirects
@@ -241,3 +241,4 @@ https://bisq.io https://bisq.network 301
 /markets https://bisq.markets 301
 
 /bisq-2 /blog/bisq-2-now-in-beta 302
+/bisq-easy https://www.youtube.com/watch?v=OILRE7DVX9E 302


### PR DESCRIPTION
This new https://bisq.network/bisq-easy redirect points to the same [Bisq Easy introduction video](https://www.youtube.com/watch?v=OILRE7DVX9E) as is embedded in Bisq 2 itself. This is a quick way to be able to share links in chat, X and elsewhere for users to find out more about Bisq Easy, and it's set up as a 302 so we can easily point to a different resource in the future.

