### PR TITLE
Replace remaining Keybase mentions with Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Please submit proposed changes as pull requests, ideally with commit messages th
 
 If you're expecting compensation from the Bisq DAO for your work, please make sure you've corresponded with the repo's maintainer to ensure the work you plan to do is currently prioritized and budgeted.
 
-You can do this by opening an issue in this repo explaining your proposed changes and cost, or by floating the idea in the #website channel on [Keybase](https://keybase.io/team/bisq).
-
 See further details on the [this wiki page](https://bisq.wiki/Growth_Team#Processes).
 
 ---

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -50,7 +50,7 @@ homepage_content:
   hPrivate: Private
   pPrivate: Your data is stored locally on-disk, and is never sent to a central server. Every Bisq node is a Tor hidden service by default.
   hOpen: Open
-  pOpen: "<p class=\"grey px-md-5\">Code is <a href=\"https://github.com/bisq-network/bisq\" target=\"_blank\" rel=\"noopener\">open-source</a>, and project strategy is discussed openly on <a href=\"https://keybase.io/team/bisq\" target=\"_blank\" rel=\"noopener\">Keybase</a> and <a href=\"https://github.com/bisq-network/bisq\" target=\"_blank\" rel=\"noopener\">GitHub</a>.</p>"
+  pOpen: "<p class=\"grey px-md-5\">Code is <a href=\"https://github.com/bisq-network/bisq\" target=\"_blank\" rel=\"noopener\">open-source</a>, and project strategy is discussed openly on <a href=\"https://bisq.chat\" target=\"_blank\" rel=\"noopener\">Matrix</a> and <a href=\"https://github.com/bisq-network/bisq\" target=\"_blank\" rel=\"noopener\">GitHub</a>.</p>"
   hEasy: Easy to Use
   pEasy: "<p class=\"grey px-md-5\">We've made all this sophistication simple—<a href='/getting-started'>make your first trade</a> in under 10 minutes!</p>"
   hBisqDao: The Bisq DAO
@@ -142,7 +142,7 @@ getting_started:
   h3Intro: This guide covers just what you need to get trading quickly!
   liIntroPoint1: Most videos below are just about 2 minutes long.
   liIntroPoint2: Written documentation is linked below too, if you prefer it.
-  liIntroPoint3: <a href="https://keybase.io/team/bisq" target="_blank">Support</a> is never too far away.
+  liIntroPoint3: <a href="https://bisq.chat" target="_blank">Support</a> is never too far away.
   pIntroNote1: Before you can start trading on Bisq, you'll need a little bitcoin for a security deposit and fees (0.01 BTC should be enough). Each trader must lock bitcoin in a multisignature escrow until the trade is complete—this is part of what makes trading on Bisq highly secure.
   pIntroNote2: <a href="https://bisq.wiki/Funding_your_wallet#How_to_Obtain_Your_First_Bitcoin" target="_blank">Here are some tips</a> on getting this bitcoin without surrendering your data to a corporate, centralized exchange.
   step1Title: Download and Install Bisq
@@ -178,5 +178,5 @@ getting_started:
   step4VideoOption2: Take Offer & Complete Trade
   thatsIt: That's it—the bare essentials of getting started with Bisq.
   nextStep1: Browse the <a href="https://bisq.wiki/" target="_blank">wiki</a> to learn more.
-  nextStep2: Say hi on <a href="https://keybase.io/team/bisq" target="_blank">Keybase</a>.
+  nextStep2: Say hi on <a href="https://bisq.chat" target="_blank">Matrix</a>.
   nextStep3: Or simply make another trade!

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,7 +91,7 @@
                 "https://lists.bisq.network/listinfo/bisq-contrib",
                 "https://webchat.freenode.net/?channels=bisq",
                 "https://www.reddit.com/r/bisq",
-                "https://keybase.io/team/bisq"
+                "https://bisq.chat"
 	          ]
             },
             "downloadUrl": "https://bisq.network/downloads/",


### PR DESCRIPTION
Most Keybase references were removed or replaced in earlier commits, but
one outlier remained on the homepage. This commit replaces it with its
Matrix equivalent.

Note that the i18n files under _data still have many references to
keybase, but these translation strings are not in use now, and were
actually never in use on the production website. As such, I've left them
alone here, instead of expending the effort to change them when they are
effectively dead code, and I've forgone removing them, so as to save
that change for a more comprehensive cleanup that may occur later. This
commit is just a quick surgical fix.

Thanks to @kciouv for reporting the issue!
