### PR TITLE
minor text adjustment

### DIFF
--- a/_posts/2024-03-16-bisq-2-now-in-beta.md
+++ b/_posts/2024-03-16-bisq-2-now-in-beta.md
@@ -20,4 +20,4 @@ Getting started with Bisq 2 is easy:
 2. Try the new [Bisq Easy](/bisq-easy) trade protocol
 3. Share your feedback in the integrated p2p group chat
 
-Note: If you're already running Bisq 1, carry on! Bisq 2 is a separate application and will install and run alongside Bisq 1 without issue.
+Note: Already running Bisq 1? No problem! Bisq 2 is a separate application and will install and run alongside Bisq 1 without issue.


### PR DESCRIPTION
I find the `carry on!` statement in the current text of the Bisq2 webpage slightly confusing.

When reading for the first time, it feels as an indication to keep using Bisq 1 and not Bisq 2. Only with the rest of the sentence things become clear.

This PR changes the wording slightly to be more clear on the fact that current Bisq 1 users can install Bisq 2 without issues.

<!-------------------------------------

IMPORTANT: Please read.

Thanks for helping to improve the Bisq website.

If you're just helping out and don't expect compensation for this 
contribution, thank you—please skip the note below and proceed.

If you're expecting compensation from the Bisq DAO for this pull request,
please make sure you've corresponded with the repo's maintainer to
ensure it's work that is currently prioritized and budgeted.

You can do this by opening an issue explaining your proposed changes and
cost, or by floating the idea in the Growth channel on Matrix (https://matrix.to/#/#bisq.growth:bitcoin.kyoto).

For more details, see this wiki 
article (https://bisq.wiki/Growth_Team#Processes).

-------------------------------------->
