### PR TITLE
Serve CORS header for NIP-05 Nostr verification

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,6 @@
 /*
-	Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+    Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
     X-XSS-Protection: 1; mode=block
     X-Content-Type-Options: nosniff
     X-Frame-Options: SAMEORIGIN
+    Access-Control-Allow-Origin: *


### PR DESCRIPTION
This is necessary for clients to be able to access the nostr.json content

See https://nostr.how/en/guides/get-verified
