### PR TITLE
Remove self-hosted Matomo tracking code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,21 +144,5 @@
 
         {% include footer.html %}
 
-        <!-- Matomo -->
-        <script type="text/javascript">
-          var _paq = window._paq || [];
-          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-          _paq.push(['trackPageView']);
-          _paq.push(['enableLinkTracking']);
-          (function() {
-            var u="//matomo.bisq.network/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', '1']);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-          })();
-        </script>
-        <!-- End Matomo Code -->
-
     </body>
 </html>


### PR DESCRIPTION
The actual Matomo instance was decommissioned some time ago, and
attempts to get matomo.js were hanging, causing site to remain in a
still-loading state for as much as 24 seconds.

See #191
