### PR TITLE
Define mobile app header in downloads page for Bisq1

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: PGP Signaturen
   tdVerificationText2: PGP Public Key
   pSeeInstructions: "<p class=\"small\">Für macOS und Windows folgen Sie bitte den Installationsanweisungen im <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Lesen Sie <a href=\"/getting-started\">Erste Schritte mit Bisq</a> für Anweisungen, wie Sie Ihren ersten Handel abschließen können."
-  hMobileNotifications: Bisq Handy-Benachrichtigungen
+  hMobileNotifications: Bisq1 Handy-Benachrichtigungen
   pMobileNotifications: Halten Sie sich über Ihre Trades auf dem Laufenden und erhalten Sie Benachrichtigungen auf Ihrem Handy.
   bisq1ScopeNote: Die ursprüngliche Version von Bisq, die die Sicherheit des Multisig-Protokolls bietet und größere Handelsbeträge ermöglicht.
   bisq2ScopeNote: Bietet derzeit das <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> Protokoll an, um Benutzer ohne Bitcoin einfach zu onboarden und die Reichweite der Verkäufer zu erweitern. Wird eines Tages eine verbesserte Version des Multisig-Protokolls übernehmen. Erfahren Sie mehr im <a href="/blog/bisq-2-now-in-beta/">Ankündigungs-Blogpost</a>.

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -133,7 +133,7 @@ downloads:
   tdVerificationText1: PGP Signatures
   tdVerificationText2: PGP Public Key
   pSeeInstructions: "<p class=\"small\">For macOS and Windows please see our new installation instructions on the <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">See our <a href=\"/getting-started\"> Getting Started </a> page how to quickly complete your first trade.</p>"
-  hMobileNotifications: Bisq Mobile Notifications
+  hMobileNotifications: Bisq1 Mobile Notifications
   pMobileNotifications: Stay up-to-date on your trades and receive notifications on your mobile phone.
   bisq1ScopeNote: The original version of Bisq, featuring the security of the multisig protocol and allowing larger trade amounts.
   bisq2ScopeNote: Currently offering the <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> protocol to easily onboard users with no bitcoin, and extend the reach of sellers, will one day inherit a better version of the multisig protocol. Learn more in the <a href="/blog/bisq-2-now-in-beta/">announcement blog post</a>.

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: Firmas PGP
   tdVerificationText2: Clave Pública PGP
   pSeeInstructions: "<p class=\"small\">For macOS and Windows please see our new installation instructions on the <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Vea <a href=\"/getting-started\">Iniciándose con Bisq</a> para instrucciones sobre cómo completar su primer intercambio.</p>"
-  hMobileNotifications: Notificaciones móviles Bisq
+  hMobileNotifications: Notificaciones móviles Bisq1
   pMobileNotifications: Manténgase al día en sus intercambios y reciba notificaciones en su celular.
   bisq1ScopeNote: La versión original de Bisq, que ofrece la seguridad del protocolo multisig y permite cantidades de comercio más grandes.
   bisq2ScopeNote: Actualmente ofrece el protocolo <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> para facilitar la incorporación de usuarios sin bitcoin y ampliar el alcance de los vendedores. Un día heredará una versión mejorada del protocolo multisig. Aprende más en el <a href="/blog/bisq-2-now-in-beta/">post del blog de anuncio</a>.

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: PGP signatures
   tdVerificationText2: Clé publique PGP
   pSeeInstructions: "<p class=\"small\">For macOS and Windows please see our new installation instructions on the <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Voir <a href=\"/getting-started\">Pour commencer avec Bisq</a> pour obtenir des instructions sur la façon d'effectuer votre premier échange.</p>"
-  hMobileNotifications: Notifications Bisq sur téléphone portable
+  hMobileNotifications: Notifications Bisq1 sur téléphone portable
   pMobileNotifications: Restez au fait de l'évolution de vos transactions et recevez des notifications sur votre téléphone portable.
   bisq1ScopeNote: La version originale de Bisq, offrant la sécurité du protocole multisig et permettant des montants de transaction plus importants.
   bisq2ScopeNote: Propose actuellement le protocole <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> pour intégrer facilement les utilisateurs sans bitcoin et étendre la portée des vendeurs. Un jour, elle héritera d'une version améliorée du protocole multisig. En savoir plus dans le <a href="/blog/bisq-2-now-in-beta/">post du blog d'annonce</a>.

--- a/_data/ja.yml
+++ b/_data/ja.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: PGP署名
   tdVerificationText2: PGPパブリックキー
   pSeeInstructions: "<p class=\"small\">macOSとWindowsについては、<a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>の新しいインストール手順をご覧ください。</p><p class=\"small\">最初のトレードを完了する方法については<a href=\"/getting-started\">Bisqの概要</a>をご覧ください。</p>"
-  hMobileNotifications: Bisqモバイル通知
+  hMobileNotifications: Bisq1モバイル通知
   pMobileNotifications: トレードを最新の状態に保ち、携帯電話で通知を受け取りましょう。
   bisq1ScopeNote: マルチシグプロトコルのセキュリティを提供し、より大きな取引額を可能にするBisqのオリジナルバージョン。
   bisq2ScopeNote: 現在、<a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a>プロトコルを提供しており、ビットコインを持っていないユーザーのオンボーディングを簡単にし、販売者のリーチを拡大しています。将来的には、マルチシグプロトコルのより良いバージョンを継承する予定です。詳細は<a href="/blog/bisq-2-now-in-beta/">発表ブログ投稿</a>をご覧ください。

--- a/_data/pt-BR.yml
+++ b/_data/pt-BR.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: "Assinaturas PGP"
   tdVerificationText2: Chave Pública PGP
   pSeeInstructions: "<p class=\"small\">Para macOS e Windows, consulte nossas novas instruções de instalação no site <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Veja <a href=\"/getting-started\">Introdução ao Bisq</a> para instruções sobre como fazer sua primeira negociação.</p>"
-  hMobileNotifications: Notificações da Bisq Móvel
+  hMobileNotifications: Notificações da Bisq1 Móvel
   pMobileNotifications: Mantenha-se atualizado sobre suas negociações e receba notificações no seu celular.
   bisq1ScopeNote: A versão original do Bisq, oferecendo a segurança do protocolo multisig e permitindo quantias maiores de negociação.
   bisq2ScopeNote: Atualmente, oferece o protocolo <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> para facilitar a integração de usuários sem bitcoin e expandir o alcance dos vendedores. Um dia, herdará uma versão aprimorada do protocolo multisig. Saiba mais no <a href="/blog/bisq-2-now-in-beta/">post de anúncio do blog</a>.

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: Assinaturas PGP
   tdVerificationText2: Chave Pública PGP
   pSeeInstructions: "<p class=\"small\">Para macOS e Windows, consulte as nossas novas instruções de instalação na página <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Confira <a href=\"/getting-started\">Getting Started with Bisq</a> para instruções de como completar a sua primeira troca.</p>"
-  hMobileNotifications: Notificações móvies do Bisq
+  hMobileNotifications: Notificações móvies do Bisq1
   pMobileNotifications: Mantenha-se atualizado sobre suas trocas e receba notificações no seu telemóvel.
   bisq1ScopeNote: A versão original do Bisq, oferecendo a segurança do protocolo multisig e permitindo quantias de negociação mais elevadas.
   bisq2ScopeNote: Atualmente, oferece o protocolo <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> para facilitar a integração de utilizadores sem bitcoin e expandir o alcance dos vendedores. Um dia, herdará uma versão melhorada do protocolo multisig. Saiba mais na <a href="/blog/bisq-2-now-in-beta/">post do blog de anúncio</a>.

--- a/_data/ru.yml
+++ b/_data/ru.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: PGP-сигнатуры
   tdVerificationText2: Откр. ключ PGP
   pSeeInstructions: "<p class=\"small\">Для macOS и Windows, пожалуйста, ознакомьтесь с нашими новыми инструкциями по установке на <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>.</p><p class=\"small\">Прочитайте статью <a href=\"/getting-started\">«Начало работы с Bisq»</a>, чтобы узнать, как совершить свою первую сделку.</p>"
-  hMobileNotifications: Мобильные уведомления Bisq
+  hMobileNotifications: Мобильные уведомления Bisq1
   pMobileNotifications: Получайте оперативные уведомления о сделках на мобильный телефон.
   bisq1ScopeNote: Оригинальная версия Bisq, обеспечивающая безопасность протокола multisig и позволяющая осуществлять сделки с большими суммами.
   bisq2ScopeNote: В настоящее время предлагает протокол <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a>, который упрощает onboarding пользователей без биткойнов и расширяет охват продавцов. Со временем он унаследует улучшенную версию протокола multisig. Узнайте больше в <a href="/blog/bisq-2-now-in-beta/">анонсирующем посте в блоге</a>.

--- a/_data/zh-CN.yml
+++ b/_data/zh-CN.yml
@@ -140,7 +140,7 @@ downloads:
   tdVerificationText1: PGP 签名
   tdVerificationText2: PGP 公钥
   pSeeInstructions: "<p class=\"small\">关于 macOS 和 Windows，请参阅 <a href=\"https://bisq.wiki/Downloading_and_installing#OS-specific_install_notes\">bisq.wiki</a>上的新安装说明。</p><p class=\"small\">有关如何完成第一笔交易的说明，请参阅如何<a href=\"/getting-started\">开始使用 Bisq</a>。</p>"
-  hMobileNotifications: Bisq 通知应用程序
+  hMobileNotifications: Bisq1 通知应用程序
   pMobileNotifications: 保持最新的交易和接收通知在您的手机上。
   bisq1ScopeNote: Bisq 的原始版本，提供 multisig 协议的安全性，并允许更大的交易金额。
   bisq2ScopeNote: 目前提供 <a href="https://bisq.wiki/Bisq_Easy">Bisq Easy</a> 协议，方便无比特币的用户进行注册，并扩展卖家的覆盖范围。未来将继承改进版的 multisig 协议。了解更多内容，请参阅 <a href="/blog/bisq-2-now-in-beta/">公告博客文章</a>。


### PR DESCRIPTION
<!-------------------------------------

IMPORTANT: Please read.

Thanks for helping to improve the Bisq website.

If you're just helping out and don't expect compensation for this 
contribution, thank you—please skip the note below and proceed.

If you're expecting compensation from the Bisq DAO for this pull request,
please make sure you've corresponded with the repo's maintainer to
ensure it's work that is currently prioritized and budgeted.

You can do this by opening an issue explaining your proposed changes and
cost, or by floating the idea in the Growth channel on Matrix (https://matrix.to/#/#bisq.growth:bitcoin.kyoto).

For more details, see this wiki 
article (https://bisq.wiki/Growth_Team#Processes).

-------------------------------------->

This PR updates the downloads page to make it clear that the mobile notifications app is only for Bisq1.
