### PR TITLE
Add link to blog in footer

### DIFF
--- a/_data/de.yml
+++ b/_data/de.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Mitarbeiten
   liMarketData: Marktdaten API
+  liBlog: Blog
   joinBisq: Treten Sie der Community bei
 
 homepage_content:

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Contribute
   liMarketData: Market Data API
+  liBlog: Blog
   joinBisq: Join the Community
 
 homepage_content:

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Contribuir
   liMarketData: API de datos de mercado
+  liBlog: Blog
   joinBisq: Unirse a la comunidad
 
 homepage_content:

--- a/_data/fr.yml
+++ b/_data/fr.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Contribuer
   liMarketData: API pour les données du marché
+  liBlog: Blog
   joinBisq: Rejoignez la communauté
 
 homepage_content:

--- a/_data/ja.yml
+++ b/_data/ja.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: 貢献
   liMarketData: 市場データAPI
+  liBlog: ブログ
   joinBisq: コミュニティに参加
 
 homepage_content:

--- a/_data/pt-BR.yml
+++ b/_data/pt-BR.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Contribuir
   liMarketData: API de dados de mercado
+  liBlog: Blog
   joinBisq: Junte-se à Comunidade
 
 homepage_content:

--- a/_data/pt-PT.yml
+++ b/_data/pt-PT.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Contribuir
   liMarketData: API de Informação de Mercado
+  liBlog: Blog
   joinBisq: Junte-se à Comunidade
 
 homepage_content:

--- a/_data/ru.yml
+++ b/_data/ru.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: Стать участником проекта
   liMarketData: API для доступа к рыночным данным
+  liBlog: Блог
   joinBisq: Присоединяйтесь к сообществу
 
 homepage_content:

--- a/_data/zh-CN.yml
+++ b/_data/zh-CN.yml
@@ -19,6 +19,7 @@ footer:
   liBenefactors: Benefactors # see https://bisq.network/benefactors for context
   liContribute: 贡献
   liMarketData: 市场数据 API
+  liBlog: 博客
   joinBisq: 加入社区
 
 homepage_content:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,13 +32,18 @@
                 <a href="/press">Press</a>
               </li>-->
               <div class="virtual-column">
-                <!--<li>
+                <li>
+                  <a href="/blog">{{ item.liBlog }}</a>
+                </li>
+              </div>
+             <!-- <div class="virtual-column">
+                &lt;!&ndash;<li>
                   <a href="https://github.com/orgs/bisq-network/projects/3" target="_blank">{{ item.liRoadmap }}</a>
-                </li>-->
+                </li>&ndash;&gt;
                 <li>
                   <a href="https://bisq.wiki/Contributor_checklist" target="_blank" rel="noopener">{{ item.liContribute }}</a>
                 </li>
-              </div>
+              </div>-->
               <div class="virtual-column">
                 <li>
                   <a href="https://markets.bisq.services/docs/api/rest" target="_blank" rel="noopener">{{ item.liMarketData }}</a>


### PR DESCRIPTION
We got recently more active blog entries again, and it would be good to keep that activity level so the link to the blog is justified again.
