### PR TITLE
fix(download): wrong url for arch linux package

### DIFF
--- a/_layouts/page_downloads.html
+++ b/_layouts/page_downloads.html
@@ -44,7 +44,7 @@ layout: page
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdArchLinux }}</td>
-      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>
+      <td><a href="https://aur.archlinux.org/packages/bisq-desktop">{{ item.tdArchLinuxText }}</a></td>
     </tr>
     <tr class="border-bottom">
       <td>{{ item.tdQubes }}</td>
@@ -124,7 +124,7 @@ layout: page
     </tr>
 <!--    <tr class="border-bottom">-->
 <!--      <td>{{ item.tdArchLinux }}</td>-->
-<!--      <td><a href="https://aur.archlinux.org/packages/bisq/">{{ item.tdArchLinuxText }}</a></td>-->
+<!--      <td><a href="https://aur.archlinux.org/packages/bisq-desktop">{{ item.tdArchLinuxText }}</a></td>-->
 <!--    </tr>-->
 <!--    <tr class="border-bottom">-->
 <!--      <td>{{ item.tdQubes }}</td>-->


### PR DESCRIPTION
Fix wrong url for arch linux package which is now bisq-desktop
