### PR TITLE
Fixes ambiguity for archive URLs

### DIFF
--- a/_layouts/page_downloads.html
+++ b/_layouts/page_downloads.html
@@ -67,8 +67,8 @@ layout: page
     <tr class="border-bottom">
       <td>{{ item.tdSourceCode }}</td>
       <td>
-        <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.zip">zip</a> |
-        <a href="https://bisq.network/downloads/archive/v{{ site.client_version }}.tar.gz">tar.gz</a>
+        <a href="https://bisq.network/downloads/archive/refs/tags/v{{ site.client_version }}.zip">zip</a> |
+        <a href="https://bisq.network/downloads/archive/refs/tags/v{{ site.client_version }}.tar.gz">tar.gz</a>
       </td>
     </tr>
     <tr class="border-bottom">
@@ -108,7 +108,8 @@ layout: page
   <div id="bisq2">&nbsp;</div>
   <h2>Bisq2 Downloads</h2>
   {{ item.bisq2ScopeNote }}
-  {% assign bisq2_archive = 'https://github.com/bisq-network/bisq2/archive' %}
+
+  {% assign bisq2_archive = 'https://github.com/bisq-network/bisq2/archive/refs/tags' %}
   {% assign bisq2_releases = 'https://github.com/bisq-network/bisq2/releases' %}
 
   <table class="all-downloads mt-5">


### PR DESCRIPTION
Fixes ambiguity for archive URLs:

https://github.com/bisq-network/bisq2/archive/refs/tags/v2.1.10.zip and
https://github.com/bisq-network/bisq2/archive/refs/heads/v2.1.10.zip

See https://github.com/bisq-network/bisq2/issues/4608#issuecomment-4203845085

