### PR TITLE
Update mobile download links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,8 +41,8 @@ paginate: 10
 paginate_path: "/blog/page/:num/"
 client_version: "1.10.1"
 bisq2_version: "2.1.11"
-bisqEasyMobile_version: "0.2.1"
-bisqConnectMobile_version: "0.2.1"
+bisqEasyMobile_version: "0.7.0"
+bisqConnectMobile_version: "0.5.0"
 sass:
   style: compressed
 webrick:

--- a/_layouts/page_downloads.html
+++ b/_layouts/page_downloads.html
@@ -233,7 +233,7 @@ layout: page
     <tr class="border-bottom">
       <td>{{ item.tdReleaseNotes }}</td>
       <td>
-        <a href="https://github.com/bisq-network/bisq-mobile/releases/anode_{{ site.bisqEasyMobile_version }}">{{
+        <a href="https://github.com/bisq-network/bisq-mobile/releases/tag/anode_{{ site.bisqEasyMobile_version }}">{{
           item.tdReleaseNotes }}</a>
       </td>
     </tr>
@@ -256,7 +256,6 @@ layout: page
   <p>{{ item.pBisqConnectMobile }}</p>
 
   <table class="all-downloads mt-5">
-    <tr class="border-bottom">
     <tr class="border-bottom">
       <td>Bisq Connect <span data-version="bisq-connect">{{ site.bisqConnectMobile_version }}</span></td>
       <td>
@@ -285,7 +284,7 @@ layout: page
     <tr class="border-bottom">
       <td>{{ item.tdReleaseNotes }}</td>
       <td>
-        <a href="https://github.com/bisq-network/bisq-mobile/releases/connect_{{ site.bisqConnectMobile_version }}">{{
+        <a href="https://github.com/bisq-network/bisq-mobile/releases/tag/connect_{{ site.bisqConnectMobile_version }}">{{
           item.tdReleaseNotes }}</a>
       </td>
     </tr>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -4,6 +4,10 @@
     easy: "anode_",
     connect: "connect_"
   };
+  var requiredAssets = {
+    easy: "Bisq_Easy-",
+    connect: "Bisq_Connect-"
+  };
 
   function ready(callback) {
     if (document.readyState === "loading") {
@@ -23,14 +27,28 @@
     return safeTag.replace(new RegExp("^" + escapedPrefix, "i"), "");
   }
 
-  function findLatestByPrefix(releases, prefix) {
+  function hasAsset(release, assetName) {
+    return Array.isArray(release.assets) && release.assets.some(function (asset) {
+      return asset && asset.name === assetName;
+    });
+  }
+
+  function hasExpectedAssets(release, prefix, appNamePrefix) {
+    var version = extractVersion(release.tag_name, prefix);
+    return version &&
+      hasAsset(release, appNamePrefix + version + ".apk") &&
+      hasAsset(release, "release-cert.pem");
+  }
+
+  function findLatestByPrefix(releases, prefix, appNamePrefix) {
     var matches = releases.filter(function (release) {
-      if (release.draft) {
+      if (release.draft || release.prerelease) {
         return false;
       }
 
       var tag = sanitizeTag(release.tag_name);
-      return tag.toLowerCase().indexOf(prefix.toLowerCase()) === 0;
+      return tag.toLowerCase().indexOf(prefix.toLowerCase()) === 0 &&
+        hasExpectedAssets(release, prefix, appNamePrefix);
     });
 
     if (matches.length === 0) {
@@ -90,8 +108,8 @@
         throw new Error("Unexpected GitHub API response");
       }
 
-      var easyRelease = findLatestByPrefix(releases, prefixes.easy);
-      var connectRelease = findLatestByPrefix(releases, prefixes.connect);
+      var easyRelease = findLatestByPrefix(releases, prefixes.easy, requiredAssets.easy);
+      var connectRelease = findLatestByPrefix(releases, prefixes.connect, requiredAssets.connect);
       var easyVersionElement = document.querySelector('[data-version="bisq-easy"]');
       var connectVersionElement = document.querySelector('[data-version="bisq-connect"]');
 


### PR DESCRIPTION
- Updated static mobile fallback versions to 0.7.0 and 0.5.0
- Fixed mobile release-note links to GitHub /releases/tag/...
- Removed the duplicate Bisq Connect table row.
- Hardened dynamic mobile release lookup to ignore drafts/prereleases and require both APK + release-cert.pem before rewriting links
